### PR TITLE
Discovery Client should only list Spring Boot App Services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,12 @@
 					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>
-		</plugins>
+		
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version></plugin>
+    </plugins>
 		<pluginManagement>
 			<plugins>
 			</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,6 @@
 					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>
-		
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version></plugin>
     </plugins>
 		<pluginManagement>
 			<plugins>

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -39,13 +39,13 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 
 	private static final Log log = LogFactory.getLog(KubernetesDiscoveryClient.class);
 	private static final String HOSTNAME = "HOSTNAME";
-	private static final String SPRING_BOOT_APP_LABEL = "spring-boot-app";
+
 
 	private KubernetesClient client;
 	private KubernetesDiscoveryProperties properties;
 
 	public KubernetesDiscoveryClient(KubernetesClient client,
-									 KubernetesDiscoveryProperties kubernetesDiscoveryProperties) {
+									 KubernetesDiscoveryProperties properties) {
 		this.client = client;
 		this.properties = properties;
 	}
@@ -80,7 +80,8 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 		if (Utils.isNullOrEmpty(podName) || endpoints == null) {
 			return defaultInstance;
 		}
-		if(labels != null && labels.containsKey(SPRING_BOOT_APP_LABEL) && labels.get(SPRING_BOOT_APP_LABEL).equals("true")) {
+		if(labels != null && labels.containsKey(properties.getSpringBootAppLabel())
+			&& labels.get(properties.getSpringBootAppLabel()).equals("true")) {
 			try {
 				List<EndpointSubset> subsets = endpoints.getSubsets();
 
@@ -114,7 +115,8 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 			labels = service.get().getMetadata().getLabels();
 		}
 		List<ServiceInstance> instances = new ArrayList<>();
-		if(labels != null && labels.containsKey(SPRING_BOOT_APP_LABEL) && labels.get(SPRING_BOOT_APP_LABEL).equals("true")) {
+		if(labels != null && labels.containsKey(properties.getSpringBootAppLabel())
+			&& labels.get(properties.getSpringBootAppLabel()).equals("true")) {
 			Optional<Endpoints> endpoints = Optional.ofNullable(client.endpoints().withName(serviceId).get());
 			List<EndpointSubset> subsets = endpoints.get().getSubsets();
 
@@ -141,8 +143,8 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 			.getItems()
 			.stream().filter(s -> {
 				if(s.getMetadata().getLabels() != null
-						&& s.getMetadata().getLabels().containsKey(SPRING_BOOT_APP_LABEL)
-						&& s.getMetadata().getLabels().get(SPRING_BOOT_APP_LABEL).equals("true")) {
+						&& s.getMetadata().getLabels().containsKey(properties.getSpringBootAppLabel())
+						&& s.getMetadata().getLabels().get(properties.getSpringBootAppLabel()).equals("true")) {
 					return true;
 				}
 				return false;

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -28,6 +28,8 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	@Value("${spring.application.name:unknown}")
 	private String serviceName = "unknown";
 
+	private String springBootAppLabel = "spring-boot-app";
+
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -38,6 +40,10 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 
 	public String getServiceName() {
 		return serviceName;
+	}
+
+	public String getSpringBootAppLabel(){
+		return springBootAppLabel;
 	}
 
 	@Override

--- a/spring-cloud-kubernetes-discovery/src/test/groovy/io/fabric8/spring/cloud/discovery/KubernetesDiscoveryClientTest.groovy
+++ b/spring-cloud-kubernetes-discovery/src/test/groovy/io/fabric8/spring/cloud/discovery/KubernetesDiscoveryClientTest.groovy
@@ -1,6 +1,8 @@
 package org.springframework.cloud.kubernetes.discovery
 
 import io.fabric8.kubernetes.api.model.EndpointsBuilder
+import io.fabric8.kubernetes.api.model.ServiceBuilder
+import io.fabric8.kubernetes.api.model.ServiceSpecBuilder
 import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.server.mock.KubernetesMockServer
@@ -18,6 +20,7 @@ class KubernetesDiscoveryClientTest extends Specification {
         mockServer.init()
         mockClient = mockServer.createClient()
 
+
         //Configure the kubernetes master url to point to the mock server
         System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl())
         System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true")
@@ -29,11 +32,26 @@ class KubernetesDiscoveryClientTest extends Specification {
         mockServer.destroy();
     }
 
-    def "Should be able to handle endpoints single address"() {
-        given:
-        mockServer.expect().get().withPath("/api/v1/namespaces/test/endpoints/endpoint").andReturn(200, new EndpointsBuilder()
+    def "Should be able to handle service with single endpoint and address"() {
+		def properties = new KubernetesDiscoveryProperties()
+		given:
+
+		Map<String, String> labels = new HashMap<>()
+		labels.put(properties.springBootAppLabel, "true")
+
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/services/my-service").andReturn(200, new ServiceBuilder()
+
+			.withNewMetadata()
+				.withName("service")
+				.withLabels(labels)
+			.endMetadata()
+
+
+			.build()).once()
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/endpoints/my-service").andReturn(200, new EndpointsBuilder()
                 .withNewMetadata()
-                    .withName("endpoint")
+                    .withName("my-service")
                 .endMetadata()
                 .addNewSubset()
                     .addNewAddress()
@@ -43,9 +61,11 @@ class KubernetesDiscoveryClientTest extends Specification {
                 .endSubset()
                 .build()).once()
 
-        DiscoveryClient discoveryClient = new KubernetesDiscoveryClient(mockClient, new KubernetesDiscoveryProperties())
+
+
+        DiscoveryClient discoveryClient = new KubernetesDiscoveryClient(mockClient, properties )
         when:
-        List<ServiceInstance> instances = discoveryClient.getInstances("endpoint")
+        List<ServiceInstance> instances = discoveryClient.getInstances("my-service")
         then:
         instances != null
         instances.size() == 1
@@ -55,11 +75,26 @@ class KubernetesDiscoveryClientTest extends Specification {
 
 
     def "Should be able to handle endpoints multiple addresses"() {
+		def properties = new KubernetesDiscoveryProperties()
         given:
-        mockServer.expect().get().withPath("/api/v1/namespaces/test/endpoints/endpoint").andReturn(200, new EndpointsBuilder()
+		Map<String, String> labels = new HashMap<>()
+		labels.put(properties.springBootAppLabel, "true")
+
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/services/my-service").andReturn(200, new ServiceBuilder()
+			.withNewMetadata()
+			.withName("my-service")
+			.withLabels(labels)
+			.endMetadata()
+
+			.build()).once()
+
+
+        mockServer.expect().get().withPath("/api/v1/namespaces/test/endpoints/my-service").andReturn(200, new EndpointsBuilder()
                 .withNewMetadata()
-                    .withName("endpoint")
+                    .withName("my-service")
+		//			.withLabels(labels)
                 .endMetadata()
+
                 .addNewSubset()
                     .addNewAddress()
                         .withIp("ip1")
@@ -71,9 +106,9 @@ class KubernetesDiscoveryClientTest extends Specification {
                 .endSubset()
                 .build()).once()
 
-        DiscoveryClient discoveryClient = new KubernetesDiscoveryClient(mockClient, new KubernetesDiscoveryProperties())
+        DiscoveryClient discoveryClient = new KubernetesDiscoveryClient(mockClient, properties)
         when:
-        List<ServiceInstance> instances = discoveryClient.getInstances("endpoint")
+        List<ServiceInstance> instances = discoveryClient.getInstances("my-service")
         then:
         instances != null
         instances.size() == 2

--- a/spring-cloud-kubernetes-discovery/src/test/groovy/io/fabric8/spring/cloud/discovery/KubernetesDiscoveryClientTest.groovy
+++ b/spring-cloud-kubernetes-discovery/src/test/groovy/io/fabric8/spring/cloud/discovery/KubernetesDiscoveryClientTest.groovy
@@ -40,7 +40,6 @@ class KubernetesDiscoveryClientTest extends Specification {
 		labels.put(properties.springBootAppLabel, "true")
 
 		mockServer.expect().get().withPath("/api/v1/namespaces/test/services/my-service").andReturn(200, new ServiceBuilder()
-
 			.withNewMetadata()
 				.withName("service")
 				.withLabels(labels)
@@ -92,7 +91,6 @@ class KubernetesDiscoveryClientTest extends Specification {
         mockServer.expect().get().withPath("/api/v1/namespaces/test/endpoints/my-service").andReturn(200, new EndpointsBuilder()
                 .withNewMetadata()
                     .withName("my-service")
-		//			.withLabels(labels)
                 .endMetadata()
 
                 .addNewSubset()


### PR DESCRIPTION
This Pull Request add a filter to the DiscoveryClient .getServices and .getServiceInstance to only retrieve services which contains a label: 
- spring-boot-app: "true" 

in their Kubernetes Service Descriptor. This has been tested with the Spring Boot Admin app (codecentric) and also with the spring cloud gateway (dynamic route discovery). 
This allow these implementations to only see spring boot apps and keeps the consistency provided by Eureka (PreKubernetes). We might want to extend the interface to provide another method which list all the services available in the kubernetes namespace. But for services that are not Spring Boot Apps I would rely on the Kubernetes Service catalog. 

I'm up for any discussion or concerns about this approach, but I do believe that we need this for consistency. 