### PR TITLE
Option to make health check fail when the Kubernetes API isn't available

### DIFF
--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesAutoConfiguration.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesAutoConfiguration.java
@@ -88,11 +88,13 @@ public class KubernetesAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(HealthIndicator.class)
+	@EnableConfigurationProperties(KubernetesHealthIndicatorProperties.class)
     protected static class KubernetesActuatorConfiguration {
         @Bean
         @ConditionalOnMissingBean
-        public KubernetesHealthIndicator kubernetesHealthIndicator(PodUtils podUtils) {
-            return new KubernetesHealthIndicator(podUtils);
+        public KubernetesHealthIndicator kubernetesHealthIndicator(PodUtils podUtils,
+																   KubernetesHealthIndicatorProperties properties) {
+            return new KubernetesHealthIndicator(podUtils, properties);
         }
     }
 

--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesHealthIndicator.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesHealthIndicator.java
@@ -24,9 +24,11 @@ import io.fabric8.kubernetes.api.model.Pod;
 public class KubernetesHealthIndicator extends AbstractHealthIndicator {
 
     private PodUtils utils;
+    private KubernetesHealthIndicatorProperties properties;
 
-    public KubernetesHealthIndicator(PodUtils utils) {
+    public KubernetesHealthIndicator(PodUtils utils, KubernetesHealthIndicatorProperties properties) {
         this.utils = utils;
+        this.properties = properties;
     }
 
     @Override
@@ -43,8 +45,13 @@ public class KubernetesHealthIndicator extends AbstractHealthIndicator {
                         .withDetail("nodeName", current.getSpec().getNodeName())
                         .withDetail("hostIp", current.getStatus().getHostIP());
             } else {
-                builder.up()
-                        .withDetail("inside", false);
+            	if (this.properties.isFailOutsidePod()) {
+            		builder.down()
+						.withDetail("inside", false);
+				} else {
+					builder.up()
+						.withDetail("inside", false);
+				}
             }
         } catch (Exception e) {
             builder.down(e);

--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesHealthIndicatorProperties.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesHealthIndicatorProperties.java
@@ -1,0 +1,17 @@
+package org.springframework.cloud.kubernetes;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.cloud.kubernetes.health")
+public class KubernetesHealthIndicatorProperties {
+	private boolean failOutsidePod = false;
+
+
+	public boolean isFailOutsidePod() {
+		return failOutsidePod;
+	}
+
+	public void setFailOutsidePod(boolean failOutsidePod) {
+		this.failOutsidePod = failOutsidePod;
+	}
+}


### PR DESCRIPTION
Adds an option (`spring.cloud.kubernetes.health.failOutsidePod`) that
causes the health indicator to report as down when Spring hasn't
communicated with the Kubernetes API correctly.

We have had occasional issues with pods that start up and report as healthy but aren't actually picking things up from the Kubernetes API servers. Applying this setting through a Pod template & environment variable should let k8s fix the problem for us and prevent traffic from ever reaching them.