### PR TITLE
Initial Service Filtering using Spel Expression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,7 @@
 
 	<dependencyManagement>
 		<dependencies>
-			<dependency>
-				<groupId>org.codehaus.groovy</groupId>
-				<artifactId>groovy-all</artifactId>
-				<version>${groovy.version}</version>
-			</dependency>
-
+			
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-kubernetes-dependencies</artifactId>

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -145,12 +145,12 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 
     @Override
     public List<String> getServices() {
-        String spelExpresion = properties.getFilter();
+        String spelExpression = properties.getFilter();
         Predicate<Service> filteredServices;
-        if (spelExpresion == null || spelExpresion.isEmpty()) {
+        if (spelExpression == null || spelExpression.isEmpty()) {
             filteredServices = (Service instance) -> true;
         } else {
-            Expression filterExpr = parser.parseExpression(spelExpresion);
+            Expression filterExpr = parser.parseExpression(spelExpression);
             filteredServices = (Service instance) -> {
                 Boolean include = filterExpr.getValue(evalCtxt, instance, Boolean.class);
                 if (include == null) {

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -29,7 +29,7 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	@Value("${spring.application.name:unknown}")
 	private String serviceName = "unknown";
 
-        /** SpEL expression to filter services **/
+    /** SpEL expression to filter services **/
 	private String filter = "";
 
 	public boolean isEnabled() {
@@ -47,8 +47,8 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	public String getFilter() {
 		return filter;
 	}
-        
-    public void setFilter(String filter){
+	
+	public void setFilter(String filter){
         this.filter = filter;
     }
 

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -48,9 +48,9 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 		return filter;
 	}
         
-        public void setFilter(String filter){
-                this.filter = filter;
-        }
+    public void setFilter(String filter){
+            this.filter = filter;
+    }
 
 	@Override
 	public String toString() {

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -47,6 +47,10 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	public String getFilter() {
 		return filter;
 	}
+        
+        public void setFilter(String filter){
+                this.filter = filter;
+        }
 
 	@Override
 	public String toString() {

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -49,7 +49,7 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	}
         
     public void setFilter(String filter){
-            this.filter = filter;
+        this.filter = filter;
     }
 
 	@Override

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -29,6 +29,9 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	@Value("${spring.application.name:unknown}")
 	private String serviceName = "unknown";
 
+        /** SpEL expression to filter services **/
+	private String filter = "";
+
 	public boolean isEnabled() {
 		return enabled;
 	}
@@ -39,6 +42,10 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 
 	public String getServiceName() {
 		return serviceName;
+	}
+
+	public String getFilter() {
+		return filter;
 	}
 
 	@Override

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -29,7 +29,9 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	@Value("${spring.application.name:unknown}")
 	private String serviceName = "unknown";
 
-    /** SpEL expression to filter services **/
+	/** 
+	* SpEL expression to filter services 
+	**/
 	private String filter = "";
 
 	public boolean isEnabled() {
@@ -49,8 +51,8 @@ public class KubernetesDiscoveryProperties extends AutoServiceRegistrationProper
 	}
 	
 	public void setFilter(String filter){
-        this.filter = filter;
-    }
+		this.filter = filter;
+	}
 
 	@Override
 	public String toString() {

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.kubernetes.discovery;
+
+import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.stream;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesDiscoveryClientTest {
+
+   
+        
+    
+	@Mock
+	private KubernetesClient kubernetesClient;
+
+        @Mock
+        private KubernetesDiscoveryProperties properties;
+        
+        @Mock
+	private MixedOperation<Service, ServiceList, DoneableService, Resource<Service, DoneableService>> serviceOperation;
+        
+
+	@InjectMocks
+	private KubernetesDiscoveryClient underTest;
+
+	@Before
+	public void setUp() throws Exception {
+		
+	}
+        
+        
+
+	@Test
+	public void testFilteredServices() throws Exception {
+                List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB");
+                List<Service> services  = createSpringBootServiceByName(springBootServiceNames);
+                
+                // Add non spring boot service
+                Service service = new Service();
+                ObjectMeta objectMeta = new ObjectMeta();
+                objectMeta.setName("ServiceNonSpringBoot");
+                service.setMetadata(objectMeta);
+                services.add(service);
+                
+                ServiceList serviceList = new ServiceList();
+		serviceList.setItems(services);
+		when(serviceOperation.list())
+			.thenReturn(serviceList);
+		when(kubernetesClient.services()).thenReturn(serviceOperation);
+                
+                when(properties.getFilter()).thenReturn("metadata.additionalProperties['spring-boot']");
+
+		
+                List<String> filteredServices = underTest.getServices();
+                
+                System.out.println("Filtered Services: " + filteredServices);
+                assertEquals(springBootServiceNames, filteredServices );
+
+	}
+
+	@Test
+	public void testFilteredServicesByPrefix() throws Exception {
+                List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB", "serviceC");
+                List<Service> services  = createSpringBootServiceByName(springBootServiceNames);
+                
+                // Add non spring boot service
+                Service service = new Service();
+                ObjectMeta objectMeta = new ObjectMeta();
+                objectMeta.setName("anotherService");
+                service.setMetadata(objectMeta);
+                services.add(service);
+                
+                ServiceList serviceList = new ServiceList();
+		serviceList.setItems(services);
+		when(serviceOperation.list())
+			.thenReturn(serviceList);
+		when(kubernetesClient.services()).thenReturn(serviceOperation);
+                
+                when(properties.getFilter()).thenReturn("metadata.name.startsWith('service')");
+
+		
+                List<String> filteredServices = underTest.getServices();
+                
+                System.out.println("Filtered Services: " + filteredServices);
+                assertEquals(springBootServiceNames, filteredServices );
+
+	}
+        
+        
+        @Test
+	public void testNoExpression() throws Exception {
+                List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB", "serviceC");
+                List<Service> services  = createSpringBootServiceByName(springBootServiceNames);
+                
+                ServiceList serviceList = new ServiceList();
+		serviceList.setItems(services);
+		when(serviceOperation.list())
+			.thenReturn(serviceList);
+		when(kubernetesClient.services()).thenReturn(serviceOperation);
+                
+                when(properties.getFilter()).thenReturn("");
+
+		
+                List<String> filteredServices = underTest.getServices();
+                
+                System.out.println("Filtered Services: " + filteredServices);
+                assertEquals(springBootServiceNames, filteredServices );
+
+	}
+
+	private List<Service> createSpringBootServiceByName(List<String> serviceNames) {
+                List<Service> serviceCollection = new ArrayList<>(serviceNames.size());
+                for(String serviceName : serviceNames){
+                    Service service = new Service();
+                    ObjectMeta objectMeta = new ObjectMeta();
+                    objectMeta.setName(serviceName);
+                    objectMeta.setAdditionalProperty("spring-boot", "true");
+                    service.setMetadata(objectMeta);
+                    serviceCollection.add(service);
+                }    
+		return serviceCollection;
+	}
+
+
+
+
+}

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-
 package org.springframework.cloud.kubernetes.discovery;
 
 import io.fabric8.kubernetes.api.model.*;
@@ -25,147 +24,120 @@ import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
-import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.util.Arrays.stream;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesDiscoveryClientTest {
 
-   
-        
-    
-	@Mock
-	private KubernetesClient kubernetesClient;
+    @Mock
+    private KubernetesClient kubernetesClient;
 
-        @Mock
-        private KubernetesDiscoveryProperties properties;
-        
-        @Mock
-	private MixedOperation<Service, ServiceList, DoneableService, Resource<Service, DoneableService>> serviceOperation;
-        
+    @Mock
+    private KubernetesDiscoveryProperties properties;
 
-	@InjectMocks
-	private KubernetesDiscoveryClient underTest;
+    @Mock
+    private MixedOperation<Service, ServiceList, DoneableService, Resource<Service, DoneableService>> serviceOperation;
 
-	@Before
-	public void setUp() throws Exception {
-		
-	}
-        
-        
+    @InjectMocks
+    private KubernetesDiscoveryClient underTest;
 
-	@Test
-	public void testFilteredServices() throws Exception {
-                List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB");
-                List<Service> services  = createSpringBootServiceByName(springBootServiceNames);
-                
-                // Add non spring boot service
-                Service service = new Service();
-                ObjectMeta objectMeta = new ObjectMeta();
-                objectMeta.setName("ServiceNonSpringBoot");
-                service.setMetadata(objectMeta);
-                services.add(service);
-                
-                ServiceList serviceList = new ServiceList();
-		serviceList.setItems(services);
-		when(serviceOperation.list())
-			.thenReturn(serviceList);
-		when(kubernetesClient.services()).thenReturn(serviceOperation);
-                
-                when(properties.getFilter()).thenReturn("metadata.additionalProperties['spring-boot']");
+    @Before
+    public void setUp() throws Exception {
 
-		
-                List<String> filteredServices = underTest.getServices();
-                
-                System.out.println("Filtered Services: " + filteredServices);
-                assertEquals(springBootServiceNames, filteredServices );
+    }
 
-	}
+    @Test
+    public void testFilteredServices() throws Exception {
+        List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB");
+        List<Service> services = createSpringBootServiceByName(springBootServiceNames);
 
-	@Test
-	public void testFilteredServicesByPrefix() throws Exception {
-                List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB", "serviceC");
-                List<Service> services  = createSpringBootServiceByName(springBootServiceNames);
-                
-                // Add non spring boot service
-                Service service = new Service();
-                ObjectMeta objectMeta = new ObjectMeta();
-                objectMeta.setName("anotherService");
-                service.setMetadata(objectMeta);
-                services.add(service);
-                
-                ServiceList serviceList = new ServiceList();
-		serviceList.setItems(services);
-		when(serviceOperation.list())
-			.thenReturn(serviceList);
-		when(kubernetesClient.services()).thenReturn(serviceOperation);
-                
-                when(properties.getFilter()).thenReturn("metadata.name.startsWith('service')");
+        // Add non spring boot service
+        Service service = new Service();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setName("ServiceNonSpringBoot");
+        service.setMetadata(objectMeta);
+        services.add(service);
 
-		
-                List<String> filteredServices = underTest.getServices();
-                
-                System.out.println("Filtered Services: " + filteredServices);
-                assertEquals(springBootServiceNames, filteredServices );
+        ServiceList serviceList = new ServiceList();
+        serviceList.setItems(services);
+        when(serviceOperation.list())
+                .thenReturn(serviceList);
+        when(kubernetesClient.services()).thenReturn(serviceOperation);
 
-	}
-        
-        
-        @Test
-	public void testNoExpression() throws Exception {
-                List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB", "serviceC");
-                List<Service> services  = createSpringBootServiceByName(springBootServiceNames);
-                
-                ServiceList serviceList = new ServiceList();
-		serviceList.setItems(services);
-		when(serviceOperation.list())
-			.thenReturn(serviceList);
-		when(kubernetesClient.services()).thenReturn(serviceOperation);
-                
-                when(properties.getFilter()).thenReturn("");
+        when(properties.getFilter()).thenReturn("metadata.additionalProperties['spring-boot']");
 
-		
-                List<String> filteredServices = underTest.getServices();
-                
-                System.out.println("Filtered Services: " + filteredServices);
-                assertEquals(springBootServiceNames, filteredServices );
+        List<String> filteredServices = underTest.getServices();
 
-	}
+        System.out.println("Filtered Services: " + filteredServices);
+        assertEquals(springBootServiceNames, filteredServices);
 
-	private List<Service> createSpringBootServiceByName(List<String> serviceNames) {
-                List<Service> serviceCollection = new ArrayList<>(serviceNames.size());
-                for(String serviceName : serviceNames){
-                    Service service = new Service();
-                    ObjectMeta objectMeta = new ObjectMeta();
-                    objectMeta.setName(serviceName);
-                    objectMeta.setAdditionalProperty("spring-boot", "true");
-                    service.setMetadata(objectMeta);
-                    serviceCollection.add(service);
-                }    
-		return serviceCollection;
-	}
+    }
 
+    @Test
+    public void testFilteredServicesByPrefix() throws Exception {
+        List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB", "serviceC");
+        List<Service> services = createSpringBootServiceByName(springBootServiceNames);
 
+        // Add non spring boot service
+        Service service = new Service();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setName("anotherService");
+        service.setMetadata(objectMeta);
+        services.add(service);
 
+        ServiceList serviceList = new ServiceList();
+        serviceList.setItems(services);
+        when(serviceOperation.list())
+                .thenReturn(serviceList);
+        when(kubernetesClient.services()).thenReturn(serviceOperation);
+
+        when(properties.getFilter()).thenReturn("metadata.name.startsWith('service')");
+
+        List<String> filteredServices = underTest.getServices();
+
+        System.out.println("Filtered Services: " + filteredServices);
+        assertEquals(springBootServiceNames, filteredServices);
+
+    }
+
+    @Test
+    public void testNoExpression() throws Exception {
+        List<String> springBootServiceNames = Arrays.asList("serviceA", "serviceB", "serviceC");
+        List<Service> services = createSpringBootServiceByName(springBootServiceNames);
+
+        ServiceList serviceList = new ServiceList();
+        serviceList.setItems(services);
+        when(serviceOperation.list())
+                .thenReturn(serviceList);
+        when(kubernetesClient.services()).thenReturn(serviceOperation);
+
+        when(properties.getFilter()).thenReturn("");
+
+        List<String> filteredServices = underTest.getServices();
+
+        System.out.println("Filtered Services: " + filteredServices);
+        assertEquals(springBootServiceNames, filteredServices);
+
+    }
+
+    private List<Service> createSpringBootServiceByName(List<String> serviceNames) {
+        List<Service> serviceCollection = new ArrayList<>(serviceNames.size());
+        for (String serviceName : serviceNames) {
+            Service service = new Service();
+            ObjectMeta objectMeta = new ObjectMeta();
+            objectMeta.setName(serviceName);
+            objectMeta.setAdditionalProperty("spring-boot", "true");
+            service.setMetadata(objectMeta);
+            serviceCollection.add(service);
+        }
+        return serviceCollection;
+    }
 
 }


### PR DESCRIPTION
This PR includes an initial filter implementation using an SPEL expression.
You can add a filter for your services by setting the property:
spring.cloud.kubernetes.discovery.filter = metadata.additionalProperties['spring-boot']