### PR TITLE
Rationalize ConfigMap usage when paths (mounted files) are involved

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -224,6 +224,12 @@ spec:
 - check the security configuration section, to access config maps from inside a pod you need to have the correct
 Kubernetes service accounts, roles and role bindings.
 
+Another option for using ConfigMaps, is to mount them into the Pod running the Spring Cloud Kubernetes application
+and have Spring Cloud Kubernetes read them from the file system.
+This behavior is controlled by the `spring.cloud.kubernetes.config.paths` property and can be used in
+addition to or instead of the mechanism described earlier.
+Multiple (exact) file paths can be specified in `spring.cloud.kubernetes.config.paths` by using the `,` delimiter
+
 .Properties:
 [options="header,footer"]
 |===
@@ -231,7 +237,7 @@ Kubernetes service accounts, roles and role bindings.
 | spring.cloud.kubernetes.config.enabled   | Boolean | true                       | Enable Secrets PropertySource
 | spring.cloud.kubernetes.config.name      | String  | ${spring.application.name} | Sets the name of ConfigMap to lookup
 | spring.cloud.kubernetes.config.namespace | String  | Client namespace           | Sets the Kubernetes namespace where to lookup
-| spring.cloud.kubernetes.config.paths     | List    | null                       | Sets the paths where ConfigMaps are mounted
+| spring.cloud.kubernetes.config.paths     | List    | []                         | Sets the paths where ConfigMaps are mounted
 | spring.cloud.kubernetes.config.enableApi | Boolean | true                       | Enable/Disable consuming ConfigMaps via APIs
 |===
 

--- a/docs/src/main/asciidoc/property-source-config.adoc
+++ b/docs/src/main/asciidoc/property-source-config.adoc
@@ -178,6 +178,12 @@ spec:
 - check the security configuration section, to access config maps from inside a pod you need to have the correct
 Kubernetes service accounts, roles and role bindings.
 
+Another option for using ConfigMaps, is to mount them into the Pod running the Spring Cloud Kubernetes application
+and have Spring Cloud Kubernetes read them from the file system.
+This behavior is controlled by the `spring.cloud.kubernetes.config.paths` property and can be used in
+addition to or instead of the mechanism described earlier.
+Multiple (exact) file paths can be specified in `spring.cloud.kubernetes.config.paths` by using the `,` delimiter
+
 .Properties:
 [options="header,footer"]
 |===

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -17,31 +17,23 @@
 
 package org.springframework.cloud.kubernetes.config;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.KEY_VALUE_TO_PROPERTIES;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.PROPERTIES_TO_MAP;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.yamlParserGenerator;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
-import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 
-import static java.util.Arrays.asList;
-import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.ABSTAIN;
-import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.FOUND;
-import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.NOT_FOUND;
-
-public class ConfigMapPropertySource extends KubernetesPropertySource {
+public class ConfigMapPropertySource extends MapPropertySource {
 	private static final Log LOG = LogFactory.getLog(ConfigMapPropertySource.class);
 
 	private static final String APPLICATION_YML = "application.yml";
@@ -50,20 +42,14 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 
 	private static final String PREFIX = "configmap";
 
-	public ConfigMapPropertySource(KubernetesClient client, String name,
-			ConfigMapConfigProperties config) {
-		this(client, name, null, config);
-	}
-
-	public ConfigMapPropertySource(KubernetesClient client, String name,
-			String[] profiles, ConfigMapConfigProperties config) {
-		this(client, name, null, profiles, config);
+	public ConfigMapPropertySource(KubernetesClient client, String name) {
+		this(client, name, null, null);
 	}
 
 	public ConfigMapPropertySource(KubernetesClient client, String name, String namespace,
-			String[] profiles, ConfigMapConfigProperties config) {
+		String[] profiles) {
 		super(getName(client, name, namespace),
-				asObjectMap(getData(client, name, namespace, profiles, config)));
+				asObjectMap(getData(client, name, namespace, profiles)));
 	}
 
 	private static String getName(KubernetesClient client, String name,
@@ -77,28 +63,22 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 	}
 
 	private static Map<String, String> getData(KubernetesClient client, String name,
-			String namespace, String[] profiles, ConfigMapConfigProperties config) {
-		Map<String, String> result = new HashMap<>();
-		if (config.isEnableApi()) {
-			try {
-				ConfigMap map = StringUtils.isEmpty(namespace)
-						? client.configMaps().withName(name).get()
-						: client.configMaps().inNamespace(namespace).withName(name).get();
+		String namespace, String[] profiles) {
+		try {
+			ConfigMap map = StringUtils.isEmpty(namespace)
+				? client.configMaps().withName(name).get()
+				: client.configMaps().inNamespace(namespace).withName(name).get();
 
-				if (map != null) {
-					result.putAll(processAllEntries(map.getData(), profiles));
-				}
-			}
-			catch (Exception e) {
-				LOG.warn("Can't read configMap with name: [" + name + "] in namespace:["
-						+ namespace + "]. Ignoring", e);
+			if (map != null) {
+				return processAllEntries(map.getData(), profiles);
 			}
 		}
+		catch (Exception e) {
+			LOG.warn("Can't read configMap with name: [" + name + "] in namespace:["
+				+ namespace + "]. Ignoring", e);
+		}
 
-		Map<String, String> configsFromPaths = new HashMap<>();
-		putPathConfig(configsFromPaths, config.getPaths());
-		result.putAll(processAllEntries(configsFromPaths, profiles));
-		return result;
+		return new HashMap<>();
 	}
 
 	private static Map<String, String> processAllEntries(Map<String, String> input,
@@ -106,6 +86,8 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 
 		Set<Entry<String, String>> entrySet = input.entrySet();
 		if (entrySet.size() == 1) {
+			// we handle the case where the configmap contains a single "file"
+			// in this case we don't care what the name of t he file is
 			Entry<String, String> singleEntry = entrySet.iterator().next();
 			String propertyName = singleEntry.getKey();
 			String propertyValue = singleEntry.getValue();
@@ -115,7 +97,8 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 							+ "] will be treated as a yaml file");
 				}
 
-				return yamlParserGenerator(profiles).andThen(PROPERTIES_TO_MAP)
+				return yamlParserGenerator(profiles).andThen(
+					PROPERTIES_TO_MAP)
 						.apply(propertyValue);
 			}
 			else if (propertyName.endsWith(".properties")) {
@@ -124,7 +107,8 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 							+ "] will be treated as a properties file");
 				}
 
-				return KEY_VALUE_TO_PROPERTIES.andThen(PROPERTIES_TO_MAP)
+				return KEY_VALUE_TO_PROPERTIES.andThen(
+					PROPERTIES_TO_MAP)
 						.apply(propertyValue);
 			}
 			else {
@@ -140,65 +124,29 @@ public class ConfigMapPropertySource extends KubernetesPropertySource {
 
 		return input.entrySet().stream()
 				.map(e -> extractProperties(e.getKey(), e.getValue(), profiles))
-				.filter(m -> !m.isEmpty()).flatMap(m -> m.entrySet().stream())
-				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+				.filter(m -> !m.isEmpty())
+				.flatMap(m -> m.entrySet().stream())
+				.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 	}
 
 	private static Map<String, String> extractProperties(String resourceName,
 			String content, String[] profiles) {
-		Map<String, String> result = new HashMap<>();
 
-		if (resourceName.equals(APPLICATION_YAML)
-				|| resourceName.equals(APPLICATION_YML)) {
-			result.putAll(yamlParserGenerator(profiles).andThen(PROPERTIES_TO_MAP)
-					.apply(content));
+		if (resourceName.equals(APPLICATION_YAML) || resourceName.equals(APPLICATION_YML)) {
+			return yamlParserGenerator(profiles).andThen(PROPERTIES_TO_MAP).apply(content);
 		}
 		else if (resourceName.equals(APPLICATION_PROPERTIES)) {
-			result.putAll(
-					KEY_VALUE_TO_PROPERTIES.andThen(PROPERTIES_TO_MAP).apply(content));
+			return KEY_VALUE_TO_PROPERTIES.andThen(PROPERTIES_TO_MAP).apply(content);
 		}
-		else {
-			result.put(resourceName, content);
-		}
-		return result;
+
+		return new HashMap<String, String>() {{
+			put(resourceName, content);
+		}};
 	}
 
 	private static Map<String, Object> asObjectMap(Map<String, String> source) {
 		return source.entrySet().stream()
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
-
-	private static Function<String, Properties> yamlParserGenerator(
-			final String[] profiles) {
-		return s -> {
-			YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();
-			yamlFactory.setDocumentMatchers(properties -> {
-				String profileProperty = properties.getProperty("spring.profiles");
-				if (profileProperty != null && profileProperty.length() > 0) {
-					return asList(profiles).contains(profileProperty) ? FOUND : NOT_FOUND;
-				}
-				else {
-					return ABSTAIN;
-				}
-			});
-			yamlFactory.setResources(new ByteArrayResource(s.getBytes()));
-			return yamlFactory.getObject();
-		};
-	}
-
-	private static final Function<String, Properties> KEY_VALUE_TO_PROPERTIES = s -> {
-		Properties properties = new Properties();
-		try {
-			properties.load(new ByteArrayInputStream(s.getBytes()));
-			return properties;
-		}
-		catch (IOException e) {
-			throw new IllegalArgumentException();
-		}
-	};
-
-	private static final Function<Properties, Map<String, String>> PROPERTIES_TO_MAP = p -> p
-			.entrySet().stream().collect(Collectors.toMap(e -> String.valueOf(e.getKey()),
-					e -> String.valueOf(e.getValue())));
 
 }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -17,10 +17,22 @@
 
 package org.springframework.cloud.kubernetes.config;
 
-import java.util.List;
+import static org.springframework.cloud.kubernetes.config.ConfigUtils.getApplicationName;
+import static org.springframework.cloud.kubernetes.config.ConfigUtils.getApplicationNamespace;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.KEY_VALUE_TO_PROPERTIES;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.PROPERTIES_TO_MAP;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.yamlParserGenerator;
 
+import io.fabric8.kubernetes.api.builder.Function;
 import io.fabric8.kubernetes.client.KubernetesClient;
-
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.cloud.kubernetes.config.ConfigMapConfigProperties.NormalizedSource;
 import org.springframework.core.annotation.Order;
@@ -30,11 +42,11 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
 
-import static org.springframework.cloud.kubernetes.config.ConfigUtils.getApplicationName;
-import static org.springframework.cloud.kubernetes.config.ConfigUtils.getApplicationNamespace;
-
 @Order(0)
 public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
+
+	private static final Log LOG = LogFactory.getLog(ConfigMapPropertySourceLocator.class);
+
 	private final KubernetesClient client;
 	private final ConfigMapConfigProperties properties;
 
@@ -51,14 +63,14 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 
 			List<ConfigMapConfigProperties.NormalizedSource> sources = properties
 					.determineSources();
-			if (sources.size() == 1) {
-				return getMapPropertySourceForSingleConfigMap(env, sources.get(0));
-			}
-
 			CompositePropertySource composite = new CompositePropertySource(
 					"composite-configmap");
-			sources.forEach(s -> composite.addFirstPropertySource(
-					getMapPropertySourceForSingleConfigMap(env, s)));
+			if (properties.isEnableApi()) {
+				sources.forEach(s -> composite.addFirstPropertySource(
+						getMapPropertySourceForSingleConfigMap(env, s)));
+			}
+
+			addPropertySourcesFromPaths(environment, composite);
 
 			return composite;
 		}
@@ -74,6 +86,65 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 						configurationTarget),
 				getApplicationNamespace(client, normalizedSource.getNamespace(),
 						configurationTarget),
-				environment.getActiveProfiles(), properties);
+				environment.getActiveProfiles());
+	}
+
+	private void addPropertySourcesFromPaths(Environment environment,
+		CompositePropertySource composite) {
+		properties
+			.getPaths()
+			.stream()
+			.map(Paths::get)
+			.peek(p -> {
+				if(!Files.exists(p)) {
+					LOG.warn("Configured input path: " + p + " will be ignored because it does not exist on the file system");
+				}
+			})
+			.filter(Files::exists)
+			.peek(p -> {
+				if(!Files.isRegularFile(p)) {
+					LOG.warn("Configured input path: " + p + " will be ignored because it is not a regular file");
+				}
+			})
+			.filter(Files::isRegularFile)
+			.forEach(p -> {
+				try {
+					String content = new String(Files.readAllBytes(p)).trim();
+					String filename = p.getFileName().toString().toLowerCase();
+					if(filename.endsWith(".properties")) {
+						addPropertySourceIfNeeded(
+							c -> PROPERTIES_TO_MAP.apply(KEY_VALUE_TO_PROPERTIES.apply(c)),
+							content,
+							filename,
+							composite
+						);
+					}
+					else if(filename.endsWith(".yml") || filename.endsWith(".yaml")) {
+						addPropertySourceIfNeeded(
+							c -> PROPERTIES_TO_MAP.apply(
+								yamlParserGenerator(environment.getActiveProfiles()).apply(c)
+							),
+							content,
+							filename,
+							composite
+						);
+					}
+				} catch (IOException e) {
+					LOG.warn("Error reading input file", e);
+				}
+			});
+	}
+
+	private void addPropertySourceIfNeeded(Function<String, Map<String, String>> contentToMapFunction,
+		String content, String name, CompositePropertySource composite) {
+
+		Map<String, Object> map = new HashMap<>();
+		map.putAll(contentToMapFunction.apply(content));
+		if(map.isEmpty()) {
+			LOG.warn("Property source: " + name + "will be ignored because no properties could be found");
+		}
+		else {
+			composite.addFirstPropertySource(new MapPropertySource(name, map));
+		}
 	}
 }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
@@ -1,0 +1,58 @@
+package org.springframework.cloud.kubernetes.config;
+
+import static java.util.Arrays.asList;
+import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.ABSTAIN;
+import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.FOUND;
+import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.NOT_FOUND;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ByteArrayResource;
+
+public class PropertySourceUtils {
+
+	static final Function<String, Properties> KEY_VALUE_TO_PROPERTIES =
+		s -> {
+			Properties properties = new Properties();
+			try {
+				properties.load(new ByteArrayInputStream(s.getBytes()));
+				return properties;
+			}
+			catch (IOException e) {
+				throw new IllegalArgumentException();
+		}
+	};
+
+	static final Function<Properties, Map<String, String>> PROPERTIES_TO_MAP =
+		p -> p.entrySet()
+				.stream()
+				.collect(
+					Collectors.toMap(
+						e -> String.valueOf(e.getKey()),
+						e -> String.valueOf(e.getValue())
+					)
+				);
+
+	static Function<String, Properties> yamlParserGenerator(
+		final String[] profiles) {
+		return s -> {
+			YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();
+			yamlFactory.setDocumentMatchers(properties -> {
+				String profileProperty = properties.getProperty("spring.profiles");
+				if (profileProperty != null && profileProperty.length() > 0) {
+					return asList(profiles).contains(profileProperty) ? FOUND : NOT_FOUND;
+				}
+				else {
+					return ABSTAIN;
+				}
+			});
+			yamlFactory.setResources(new ByteArrayResource(s.getBytes()));
+			return yamlFactory.getObject();
+		};
+	}
+}

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapTestUtil.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapTestUtil.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.kubernetes.config;
 
 import io.fabric8.kubernetes.client.utils.IOHelpers;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 final class ConfigMapTestUtil {
 
@@ -36,5 +39,9 @@ final class ConfigMapTestUtil {
 			resource = "";
 		}
 		return resource;
+	}
+
+	static void createFileWithContent(String file, String content) throws IOException {
+		Files.write(Paths.get(file), content.getBytes(), StandardOpenOption.CREATE);
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsFromFilePathsSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsFromFilePathsSpringBootTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.kubernetes.config;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.springframework.cloud.kubernetes.config.ConfigMapTestUtil.createFileWithContent;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.config.example.App;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class , properties = {
+	"spring.application.name=configmap-path-example",
+	"spring.cloud.kubernetes.config.enableApi=false",
+	"spring.cloud.kubernetes.config.paths="
+		+ ConfigMapsFromFilePathsSpringBootTest.FIRST_FILE_NAME_FULL_PATH + ","
+		+ ConfigMapsFromFilePathsSpringBootTest.SECOND_FILE_NAME_FULL_PATH
+})
+public class ConfigMapsFromFilePathsSpringBootTest {
+
+	protected static final String FILES_ROOT_PATH = "/tmp/scktests";
+	protected static final String FIRST_FILE_NAME = "application.properties";
+	protected static final String SECOND_FILE_NAME = "extra.properties";
+	protected static final String UNUSED_FILE_NAME = "unused.properties";
+	protected static final String FIRST_FILE_NAME_FULL_PATH = FILES_ROOT_PATH + "/" + FIRST_FILE_NAME;
+	protected static final String SECOND_FILE_NAME_FULL_PATH = FILES_ROOT_PATH + "/" + SECOND_FILE_NAME;
+	protected static final String UNUSED_FILE_NAME_FULL_PATH = FILES_ROOT_PATH + "/" + UNUSED_FILE_NAME;
+
+	@ClassRule
+	public static KubernetesServer server = new KubernetesServer();
+
+	private static KubernetesClient mockClient;
+
+    @Autowired
+    private WebTestClient webClient;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws IOException {
+		mockClient = server.getClient();
+
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
+				mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY,
+				"false");
+		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+
+		Files.createDirectories(Paths.get(FILES_ROOT_PATH));
+		createFileWithContent(FIRST_FILE_NAME_FULL_PATH, "bean.greeting=Hello from path!");
+		createFileWithContent(SECOND_FILE_NAME_FULL_PATH, "bean.farewell=Bye from path!");
+		createFileWithContent(UNUSED_FILE_NAME_FULL_PATH, "bean.morning=Morning from path!");
+	}
+
+	@AfterClass
+	public static void teardownAfterClass() {
+		newArrayList(
+			FIRST_FILE_NAME_FULL_PATH,
+			SECOND_FILE_NAME_FULL_PATH,
+			SECOND_FILE_NAME_FULL_PATH,
+			FILES_ROOT_PATH
+		).forEach(fn -> {
+			try {
+				Files.delete(Paths.get(fn));
+			} catch (IOException ignored) {}
+		});
+	}
+
+	@Test
+	public void greetingInputShouldReturnPropertyFromFirstFile() {
+        this.webClient.get().uri("/api/greeting").exchange().expectStatus().isOk()
+                .expectBody().jsonPath("content").isEqualTo("Hello from path!");
+	}
+
+	@Test
+	public void farewellInputShouldReturnPropertyFromSecondFile() {
+        this.webClient.get().uri("/api/farewell").exchange().expectStatus().isOk()
+                .expectBody().jsonPath("content").isEqualTo("Bye from path!");
+	}
+
+	@Test
+	public void morningInputShouldReturnDefaultValue() {
+        this.webClient.get().uri("/api/morning").exchange().expectStatus().isOk()
+                .expectBody().jsonPath("content").isEqualTo("Good morning, World!");
+	}
+
+}

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsMixedSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsMixedSpringBootTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.kubernetes.config;
+
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.springframework.cloud.kubernetes.config.ConfigMapTestUtil.readResourceFile;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.config.example.App;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class , properties = {
+	"spring.application.name=" + ConfigMapsMixedSpringBootTest.APPLICATION_NAME,
+	"spring.cloud.kubernetes.config.enableApi=true",
+	"spring.cloud.kubernetes.config.paths="
+		+ ConfigMapsMixedSpringBootTest.FILE_NAME_FULL_PATH
+})
+public class ConfigMapsMixedSpringBootTest {
+
+	protected static final String FILES_ROOT_PATH = "/tmp/scktests";
+	protected static final String FILE_NAME = "application-path.yaml";
+	protected static final String FILE_NAME_FULL_PATH = FILES_ROOT_PATH + "/" + FILE_NAME;
+
+	protected static final String APPLICATION_NAME = "configmap-mixed-example";
+
+	@ClassRule
+	public static KubernetesServer server = new KubernetesServer();
+
+	private static KubernetesClient mockClient;
+
+    @Autowired
+    private WebTestClient webClient;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws IOException {
+		mockClient = server.getClient();
+
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
+				mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY,
+				"false");
+		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+
+		Files.createDirectories(Paths.get(FILES_ROOT_PATH));
+		ConfigMapTestUtil.createFileWithContent(FILE_NAME_FULL_PATH, readResourceFile("application-path.yaml"));
+
+		HashMap<String, String> data = new HashMap<>();
+		data.put("bean.morning", "Buenos Dias ConfigMap, %s");
+		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + APPLICATION_NAME)
+			.andReturn(200, new ConfigMapBuilder().withNewMetadata()
+				.withName(APPLICATION_NAME).endMetadata().addToData(data).build())
+			.always();
+	}
+
+	@AfterClass
+	public static void teardownAfterClass() {
+		newArrayList(
+			FILE_NAME_FULL_PATH,
+			FILES_ROOT_PATH
+		).forEach(fn -> {
+			try {
+				Files.delete(Paths.get(fn));
+			} catch (IOException ignored) {}
+		});
+	}
+
+	@Test
+	public void greetingInputShouldReturnPropertyFromFile() {
+        this.webClient.get().uri("/api/greeting").exchange().expectStatus().isOk()
+                .expectBody().jsonPath("content").isEqualTo("Hello ConfigMap, World from path");
+	}
+
+	@Test
+	public void farewellInputShouldReturnPropertyFromFile() {
+        this.webClient.get().uri("/api/farewell").exchange().expectStatus().isOk()
+                .expectBody().jsonPath("content").isEqualTo("Bye ConfigMap, World from path");
+	}
+
+	@Test
+	public void morningInputShouldReturnPropertyFromApi() {
+        this.webClient.get().uri("/api/morning").exchange().expectStatus().isOk()
+                .expectBody().jsonPath("content").isEqualTo("Buenos Dias ConfigMap, World");
+	}
+
+}

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingController.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingController.java
@@ -36,14 +36,17 @@ public class GreetingController {
 	}
 
 	@RequestMapping("/api/greeting")
-	public Greeting greeting(@RequestParam(value="name", defaultValue="World") String name) {
-		String message = String.format(properties.getGreeting(), name);
-		return new Greeting(message);
+	public ResponseMessage greeting(@RequestParam(value="name", defaultValue="World") String name) {
+		return new ResponseMessage(String.format(properties.getGreeting(), name));
 	}
 
 	@RequestMapping("/api/farewell")
-	public Greeting farewell(@RequestParam(value="name", defaultValue="World") String name) {
-		String message = String.format(properties.getFarewell(), name);
-		return new Greeting(message);
+	public ResponseMessage farewell(@RequestParam(value="name", defaultValue="World") String name) {
+		return new ResponseMessage(String.format(properties.getFarewell(), name));
+	}
+
+	@RequestMapping("/api/morning")
+	public ResponseMessage morning(@RequestParam(value="name", defaultValue="World") String name) {
+		return new ResponseMessage(String.format(properties.getMorning(), name));
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingProperties.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/GreetingProperties.java
@@ -26,6 +26,7 @@ public class GreetingProperties {
 
 	private String greeting = "Hello, %s!";
 	private String farewell = "Goodbye, %s!";
+	private String morning = "Good morning, %s!";
 
 	public String getGreeting() {
 		return greeting;
@@ -41,5 +42,13 @@ public class GreetingProperties {
 
 	public void setFarewell(String farewell) {
 		this.farewell = farewell;
+	}
+
+	public String getMorning() {
+		return morning;
+	}
+
+	public void setMorning(String morning) {
+		this.morning = morning;
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/ResponseMessage.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/example/ResponseMessage.java
@@ -20,15 +20,15 @@ package org.springframework.cloud.kubernetes.config.example;
 /**
  * @author Charles Moulliard
  */
-public class Greeting {
+public class ResponseMessage {
 
 	private final String content;
 
-	public Greeting() {
+	public ResponseMessage() {
 		this.content = null;
 	}
 
-	public Greeting(String content) {
+	public ResponseMessage(String content) {
 		this.content = content;
 	}
 

--- a/spring-cloud-kubernetes-config/src/test/resources/application-path.yaml
+++ b/spring-cloud-kubernetes-config/src/test/resources/application-path.yaml
@@ -1,0 +1,3 @@
+bean:
+  greeting: "Hello ConfigMap, %s from path"
+  farewell: "Bye ConfigMap, %s from path"


### PR DESCRIPTION
This is done by removing the file walking and loading logic that existed
before and replacing it with an implementation that creates on
ConfigMapResource per specified path.
Reading and processing the content of the path is done in the exact
same way as the enableApi method does thus providing a consistent
experience.

The implementation is inspired by the following comment:
https://github.com/spring-cloud/spring-cloud-kubernetes/issues/230#issuecomment-420341743

Fixes: #230