### PR TITLE
Hide secrets properties

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/SecretsPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/SecretsPropertySource.java
@@ -99,6 +99,10 @@ public class SecretsPropertySource extends KubernetesPropertySource {
 		return result;
 	}
 
+	@Override public String toString() {
+		return getClass().getSimpleName()
+	}
+
 	// *****************************
 	// Helpers
 	// *****************************

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/SecretsPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/SecretsPropertySource.java
@@ -37,28 +37,27 @@ public class SecretsPropertySource extends KubernetesPropertySource {
 	private static final String PREFIX = "secrets";
 
 	public SecretsPropertySource(KubernetesClient client, Environment env,
-			SecretsConfigProperties config) {
+		SecretsConfigProperties config) {
 		super(getSourceName(client, env, config), getSourceData(client, env, config));
 	}
 
 	private static String getSourceName(KubernetesClient client, Environment env,
-			SecretsConfigProperties config) {
+		SecretsConfigProperties config) {
 		return new StringBuilder().append(PREFIX)
-				.append(Constants.PROPERTY_SOURCE_NAME_SEPARATOR)
-				.append(getApplicationName(env, config.getName(),
-						config.getConfigurationTarget()))
-				.append(Constants.PROPERTY_SOURCE_NAME_SEPARATOR)
-				.append(getApplicationNamespace(client, config.getNamespace(),
-						config.getConfigurationTarget()))
-				.toString();
+			.append(Constants.PROPERTY_SOURCE_NAME_SEPARATOR).append(
+				getApplicationName(env, config.getName(),
+					config.getConfigurationTarget()))
+			.append(Constants.PROPERTY_SOURCE_NAME_SEPARATOR).append(
+				getApplicationNamespace(client, config.getNamespace(),
+					config.getConfigurationTarget())).toString();
 	}
 
 	private static Map<String, Object> getSourceData(KubernetesClient client,
-			Environment env, SecretsConfigProperties config) {
+		Environment env, SecretsConfigProperties config) {
 		String name = getApplicationName(env, config.getName(),
-				config.getConfigurationTarget());
+			config.getConfigurationTarget());
 		String namespace = getApplicationNamespace(client, config.getNamespace(),
-				config.getConfigurationTarget());
+			config.getConfigurationTarget());
 		Map<String, Object> result = new HashMap<>();
 
 		if (config.isEnableApi()) {
@@ -77,19 +76,20 @@ public class SecretsPropertySource extends KubernetesPropertySource {
 				if (!config.getLabels().isEmpty()) {
 					if (StringUtils.isEmpty(namespace)) {
 						client.secrets().withLabels(config.getLabels()).list().getItems()
-								.forEach(s -> putAll(s, result));
+							.forEach(s -> putAll(s, result));
 					}
 					else {
 						client.secrets().inNamespace(namespace)
-								.withLabels(config.getLabels()).list().getItems()
-								.forEach(s -> putAll(s, result));
+							.withLabels(config.getLabels()).list().getItems()
+							.forEach(s -> putAll(s, result));
 					}
 				}
 			}
 			catch (Exception e) {
-				LOG.warn("Can't read secret with name: [" + name + "] or labels ["
-						+ config.getLabels() + "] in namespace:[" + namespace
-						+ "] (cause: " + e.getMessage() + "). Ignoring");
+				LOG.warn(
+					"Can't read secret with name: [" + name + "] or labels [" + config
+						.getLabels() + "] in namespace:[" + namespace + "] (cause: " + e
+						.getMessage() + "). Ignoring");
 			}
 		}
 
@@ -99,8 +99,8 @@ public class SecretsPropertySource extends KubernetesPropertySource {
 		return result;
 	}
 
-	@Override public String toString() {
-		return getClass().getSimpleName()
+		@Override public String toString() {
+		return getClass().getSimpleName() + " {name='" + this.name + "'}";
 	}
 
 	// *****************************
@@ -108,8 +108,8 @@ public class SecretsPropertySource extends KubernetesPropertySource {
 	// *****************************
 	private static void putAll(Secret secret, Map<String, Object> result) {
 		if (secret != null && secret.getData() != null) {
-			secret.getData().forEach((k, v) -> result.put(k,
-					new String(Base64.getDecoder().decode(v)).trim()));
+			secret.getData().forEach((k, v) -> result
+				.put(k, new String(Base64.getDecoder().decode(v)).trim()));
 		}
 	}
 }

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/SecretsPropertySourceTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/SecretsPropertySourceTest.java
@@ -1,0 +1,58 @@
+package org.springframework.cloud.kubernetes.config;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.config.example.App;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Base64;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class) @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class) @TestPropertySource("classpath:/application-secrets.properties") public class SecretsPropertySourceTest {
+
+	private static final String NAMESPACE = "test";
+	private static final String SECRET_VALUE = "secretValue";
+
+	@ClassRule public static KubernetesServer server = new KubernetesServer(false, true);
+
+	@Autowired private SecretsPropertySourceLocator propertySourceLocator;
+	@Autowired private Environment environment;
+
+	@BeforeClass public static void setUpBeforeClass() {
+		KubernetesClient mockClient = server.getClient();
+
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
+			mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY,
+			"false");
+		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, NAMESPACE);
+
+		Secret secret = new SecretBuilder().withNewMetadata()
+			.withLabels(singletonMap("foo", "bar")).endMetadata()
+			.addToData("secretName", Base64.getEncoder().encodeToString(SECRET_VALUE.getBytes()))
+			.build();
+		mockClient.secrets().inNamespace(NAMESPACE).create(secret);
+	}
+
+	@Test public void toStringShouldNotExposeSecretValues() {
+		String actual = propertySourceLocator.locate(environment).toString();
+
+		assertThat(actual).doesNotContain(SECRET_VALUE);
+	}
+}

--- a/spring-cloud-kubernetes-config/src/test/resources/application-secrets.properties
+++ b/spring-cloud-kubernetes-config/src/test/resources/application-secrets.properties
@@ -1,0 +1,5 @@
+spring.application.name=configmap-example
+spring.cloud.kubernetes.reload.enabled=false
+logging.level.org.springframework.cloud.kubernetes.config.SecretsPropertySource=DEBUG
+spring.cloud.kubernetes.secrets.labels.foo=bar
+spring.cloud.kubernetes.secrets.enableApi=true


### PR DESCRIPTION
Overwrite `toString()` of `SecretsPropertySource` so no secrets are accidentally exposed
Fixes #267