### PR TITLE
docs: native kubernetes service discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,8 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
-
+# vscode + eclipse
+.settings/
+.project
+.classpath
+.factorypath

--- a/docs/src/main/asciidoc/discovery-kubernetes-native.adoc
+++ b/docs/src/main/asciidoc/discovery-kubernetes-native.adoc
@@ -1,0 +1,11 @@
+== Kubernetes native service discovery
+
+Kubernetes itself is capable of (server side) service discovery (see: https://kubernetes.io/docs/concepts/services-networking/service/#discovering-services).
+Using native kubernetes service discovery ensures compatibility with additional tooling, like: istio https://istio.io (service mesh, capable of load balancing, ribbon, circuit breaker, failover and much more).
+
+The caller service just needs to refer to names resolvable in particular kubernetes cluster then. Simplest implementation might use the spring `RestTemplate` referring to fully qualified domain name (FQDN) `http://<service-name>.<namespace>.svc.<cluster>.local:<service-port>`.
+
+Additionally, hystrix can be used for:
+
+* circuit breaker implementation on the caller side, just by annotating the spring boot application class: `@EnableCircuitBreaker`
+* and for the fallback functionality, annotating the respective method via: `@HystrixCommand(fallbackMethod=` does the job.

--- a/docs/src/main/asciidoc/spring-cloud-kubernetes.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-kubernetes.adoc
@@ -7,6 +7,8 @@ The main objective of the projects provided in this repository is to facilitate 
 
 include::discovery-client.adoc[]
 
+include::discovery-kubernetes-native.adoc[]
+
 include::property-source-config.adoc[]
 
 include::ribbon-integration.adoc[]


### PR DESCRIPTION
Documentation for the native kubernetes service discovery documented (as discussed in the: https://github.com/spring-cloud/spring-cloud-kubernetes/issues/298)