### PR TITLE
Remove exception from log when configMap can't be read

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -75,7 +75,7 @@ public class ConfigMapPropertySource extends MapPropertySource {
 		}
 		catch (Exception e) {
 			LOG.warn("Can't read configMap with name: [" + name + "] in namespace:["
-				+ namespace + "]. Ignoring", e);
+				+ namespace + "]. Ignoring");
 		}
 
 		return new HashMap<>();


### PR DESCRIPTION
The printed exception doesn't seem to add much except additional log output, i.e. (line numbers are due to being on 0.3.0):

```
 java.lang.IllegalArgumentException: Name must be provided.
at io.fabric8.kubernetes.client.dsl.base.BaseOperation.withName(BaseOperation.java:248)
at io.fabric8.kubernetes.client.dsl.base.BaseOperation.withName(BaseOperation.java:63)
at org.springframework.cloud.kubernetes.config.ConfigMapPropertySource.getData(ConfigMapPropertySource.java:85)
at org.springframework.cloud.kubernetes.config.ConfigMapPropertySource.<init>(ConfigMapPropertySource.java:66)
at org.springframework.cloud.kubernetes.config.ConfigMapPropertySourceLocator.getMapPropertySourceForSingleConfigMap(ConfigMapPropertySourceLocator.java:77)```
```

The log message `o.s.c.k.config.ConfigMapPropertySource   : Can't read configMap with name: [] in namespace:[null]. Ignoring` itself seems to be enough