### PR TITLE
Add the ability to only discover services that match certain labels

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesClientServicesFunction.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesClientServicesFunction.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.kubernetes.discovery;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+
+import java.util.function.Function;
+
+/**
+ * A regular java.util.function that is used to hide the complexity of the KubernetesClient interfaces
+ *
+ * It's meant to be used to abstract things like:
+ *
+ * client.services()
+ * client.services().withLabel("key", "value")
+ * client.services().withoutLabel("key")
+ *
+ * The result of the application of the function can then be used for example to list the services like so:
+ *
+ * function.apply(client).list()
+ *
+ * See KubernetesDiscoveryClientAutoConfiguration.servicesFunction
+ */
+public interface KubernetesClientServicesFunction extends
+	Function<KubernetesClient, FilterWatchListDeletable<Service, ServiceList, Boolean, Watch, Watcher<Service>>> {
+}

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesClientServicesFunction.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesClientServicesFunction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package org.springframework.cloud.kubernetes.discovery;
 
 import io.fabric8.kubernetes.api.model.Service;

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -16,7 +16,11 @@
  */
 package org.springframework.cloud.kubernetes.discovery;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.EndpointAddress;
+import io.fabric8.kubernetes.api.model.EndpointPort;
+import io.fabric8.kubernetes.api.model.EndpointSubset;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfiguration.java
@@ -18,7 +18,6 @@
 package org.springframework.cloud.kubernetes.discovery;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,11 +35,21 @@ import org.springframework.context.annotation.Configuration;
 public class KubernetesDiscoveryClientAutoConfiguration {
 
 	@Bean
+	public KubernetesClientServicesFunction servicesFunction(KubernetesDiscoveryProperties properties) {
+		if (properties.getServiceLabels().isEmpty())  {
+			return KubernetesClient::services;
+		}
+
+		return (client) -> client.services().withLabels(properties.getServiceLabels());
+	}
+
+	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(name = "spring.cloud.kubernetes.discovery.enabled",matchIfMissing = true)
 	public KubernetesDiscoveryClient kubernetesDiscoveryClient(KubernetesClient client,
-										   KubernetesDiscoveryProperties properties) {
-		return new KubernetesDiscoveryClient(client, properties);
+										   					   KubernetesDiscoveryProperties properties,
+															   KubernetesClientServicesFunction kubernetesClientServicesFunction) {
+		return new KubernetesDiscoveryClient(client, properties, kubernetesClientServicesFunction);
 	}
 
 	@Bean

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -21,6 +21,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.style.ToStringCreator;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @ConfigurationProperties("spring.cloud.kubernetes.discovery")
 public class KubernetesDiscoveryProperties {
 
@@ -31,8 +34,11 @@ public class KubernetesDiscoveryProperties {
 	@Value("${spring.application.name:unknown}")
 	private String serviceName = "unknown";
 
-	/** SpEL expression to filter services. */
+	/** SpEL expression to filter services AFTER they have been retrieved from the Kubernetes API server. */
 	private String filter;
+
+	/** If set, then only the services matching these labels will be fetched from the Kubernetes API server */
+	private Map<String, String> serviceLabels = new HashMap<>();
 
 	private Metadata metadata = new Metadata();
 
@@ -58,6 +64,14 @@ public class KubernetesDiscoveryProperties {
 
 	public void setFilter(String filter){
 		this.filter = filter;
+	}
+
+	public Map<String, String> getServiceLabels() {
+		return serviceLabels;
+	}
+
+	public void setServiceLabels(Map<String, String> serviceLabels) {
+		this.serviceLabels = serviceLabels;
 	}
 
 	public Metadata getMetadata() {

--- a/spring-cloud-kubernetes-discovery/src/test/groovy/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.groovy
+++ b/spring-cloud-kubernetes-discovery/src/test/groovy/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.groovy
@@ -23,12 +23,11 @@ import io.fabric8.kubernetes.api.model.ServiceListBuilder
 import io.fabric8.kubernetes.client.Config
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.server.mock.KubernetesMockServer
-import org.assertj.core.api.Assertions
 import org.springframework.cloud.client.ServiceInstance
 import org.springframework.cloud.client.discovery.DiscoveryClient
 import spock.lang.Specification
 
-import static org.assertj.core.api.Assertions.*
+import static org.assertj.core.api.Assertions.assertThat
 
 class KubernetesDiscoveryClientTest extends Specification {
 

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientFilterTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientFilterTest.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -34,6 +35,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -45,11 +48,17 @@ public class KubernetesDiscoveryClientFilterTest {
 	@Mock
 	private KubernetesDiscoveryProperties properties;
 
+	private KubernetesClientServicesFunction kubernetesClientServicesFunction = KubernetesClient::services;
+
 	@Mock
 	private MixedOperation<Service, ServiceList, DoneableService, ServiceResource<Service, DoneableService>> serviceOperation;
 
-	@InjectMocks
 	private KubernetesDiscoveryClient underTest;
+
+	@Before
+	public void setUp() {
+		underTest = new KubernetesDiscoveryClient(kubernetesClient, properties, kubernetesClientServicesFunction);
+	}
 
 	@Test
 	public void testFilteredServices() {


### PR DESCRIPTION
Arbitrary filtering of services is also possible by supplying a bean of
type `KubernetesClientServicesFunction`

This is an alternative to #308 and fixes #284 