### PR TITLE
Add profile expression support

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -94,7 +94,7 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 						configurationTarget),
 				getApplicationNamespace(this.client, normalizedSource.getNamespace(),
 						configurationTarget),
-				environment.getActiveProfiles());
+				environment);
 	}
 
 	private void addPropertySourcesFromPaths(Environment environment,
@@ -121,7 +121,7 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 				}
 				else if (filename.endsWith(".yml") || filename.endsWith(".yaml")) {
 					addPropertySourceIfNeeded(c -> PROPERTIES_TO_MAP
-							.apply(yamlParserGenerator(environment.getActiveProfiles())
+							.apply(yamlParserGenerator(environment)
 									.apply(c)),
 							content, filename, composite);
 				}

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
@@ -24,9 +24,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.util.StringUtils;
 
-import static java.util.Arrays.asList;
 import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.ABSTAIN;
 import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.FOUND;
 import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus.NOT_FOUND;
@@ -56,13 +58,14 @@ public final class PropertySourceUtils {
 		throw new IllegalStateException("Can't instantiate a utility class");
 	}
 
-	static Function<String, Properties> yamlParserGenerator(final String[] profiles) {
+	static Function<String, Properties> yamlParserGenerator(Environment environment) {
 		return s -> {
 			YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();
 			yamlFactory.setDocumentMatchers(properties -> {
-				String profileProperty = properties.getProperty("spring.profiles");
-				if (profileProperty != null && profileProperty.length() > 0) {
-					return asList(profiles).contains(profileProperty) ? FOUND : NOT_FOUND;
+				String profiles = properties.getProperty("spring.profiles");
+				if (environment != null && StringUtils.hasText(profiles)) {
+					return environment.acceptsProfiles(Profiles.of(profiles)) ? FOUND
+							: NOT_FOUND;
 				}
 				else {
 					return ABSTAIN;

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfileExpressionSpringBootTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsWithProfileExpressionSpringBootTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.config;
+
+import java.util.HashMap;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.springframework.cloud.kubernetes.config.ConfigMapTestUtil.readResourceFile;
+
+/**
+ * Tests reading property from YAML document specified by profile expression.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class, properties = {
+		"spring.application.name=configmap-with-profile-example",
+		"spring.cloud.kubernetes.reload.enabled=false" })
+@ActiveProfiles({ "production", "us-east" })
+@AutoConfigureWebTestClient
+public class ConfigMapsWithProfileExpressionSpringBootTest {
+
+	@ClassRule
+	public static KubernetesServer server = new KubernetesServer();
+
+	private static final String APPLICATION_NAME = "configmap-with-profile-example";
+
+	@Autowired
+	private WebTestClient webClient;
+
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		KubernetesClient mockClient = server.getClient();
+
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY,
+				mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY,
+				"false");
+		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+
+		HashMap<String, String> data = new HashMap<>();
+		data.put("application.yml", readResourceFile("application-with-profiles.yaml"));
+		server.expect().withPath("/api/v1/namespaces/test/configmaps/" + APPLICATION_NAME)
+				.andReturn(200, new ConfigMapBuilder().withNewMetadata()
+						.withName(APPLICATION_NAME).endMetadata().addToData(data).build())
+				.always();
+	}
+
+	@Test
+	public void testGreetingEndpoint() {
+		this.webClient.get().uri("/api/greeting").exchange().expectStatus().isOk()
+				.expectBody().jsonPath("content")
+				.isEqualTo("Hello ConfigMap production and us-east, World!");
+	}
+
+}

--- a/spring-cloud-kubernetes-config/src/test/resources/application-with-profiles.yaml
+++ b/spring-cloud-kubernetes-config/src/test/resources/application-with-profiles.yaml
@@ -11,3 +11,8 @@ spring:
   profiles: production
 bean:
   greeting: "Hello ConfigMap prod, %s!"
+---
+spring:
+  profiles: production & us-east
+bean:
+  greeting: "Hello ConfigMap production and us-east, %s!"


### PR DESCRIPTION
Spring Boot 2.1 introduced the ability to match profiles by [profile expression](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#profile-expression). For example, if a YAML document specifies

    spring.profiles: production & us-east

then the properties from the document are loaded if both the `production` and `us-east` profiles are active.