### PR TITLE
Document Spring Boot starters

### DIFF
--- a/docs/src/main/asciidoc/discovery-client.adoc
+++ b/docs/src/main/asciidoc/discovery-client.adoc
@@ -7,16 +7,6 @@ A service is typically exposed by the Kubernetes API server as a collection of e
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon project
 to fetch the list of the endpoints defined for an application to be load balanced.
 
-This is something that you get for free just by adding the following dependency inside your project:
-
-```xml
-<dependency>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-starter-kubernetes</artifactId>
-    <version>${latest.version}</version>
-</dependency>
-```
-
 To enable loading of the `DiscoveryClient`, add `@EnableDiscoveryClient` to the according configuration or application class like this:
 
 ```java

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -1,0 +1,52 @@
+== Starters
+
+Starters are convenient dependency descriptors you can include in your
+application. Include a starter to get the dependencies and Spring Boot
+auto-configuration for a feature set.
+
+[cols="a,d"]
+|===
+| Starter | Features
+
+| [source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-kubernetes</artifactId>
+</dependency>
+----
+| <<DiscoveryClient for Kubernetes,Discovery Client>> implementation that
+resolves service names to Kubernetes Services.
+
+| [source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+</dependency>
+----
+| Load application properties from Kubernetes
+<<ConfigMap PropertySource,ConfigMaps>> and <<Secrets PropertySource,Secrets>>.
+<<PropertySource Reload,Reload>> application properties when a ConfigMap or
+Secret changes.
+
+| [source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-kubernetes-ribbon</artifactId>
+</dependency>
+----
+| <<Ribbon discovery in Kubernetes,Ribbon>> client-side load balancer with
+server list obtained from Kubernetes Endpoints.
+
+| [source,xml]
+----
+<dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-kubernetes-all</artifactId>
+</dependency>
+----
+| All Spring Cloud Kubernetes features.
+
+|===

--- a/docs/src/main/asciidoc/ribbon-integration.adoc
+++ b/docs/src/main/asciidoc/ribbon-integration.adoc
@@ -7,16 +7,6 @@ implemented within the [spring-cloud-kubernetes-ribbon](spring-cloud-kubernetes-
 Kubernetes client will populate a https://github.com/Netflix/ribbon[Ribbon] `ServerList` containing information
 about such endpoints.
 
-The implementation is part of the following starter that you can use by adding its dependency to your pom file:
-
-```xml
-<dependency>
-    <groupId>org.springframework.cloud</groupId>
-    <artifactId>spring-cloud-starter-kubernetes-ribbon</artifactId>
-    <version>${latest.version}</version>
-</dependency>
-```
-
 When the list of the endpoints is populated, the Kubernetes client will search the registered endpoints living in
 the current namespace/project matching the service name defined using the Ribbon Client annotation:
 

--- a/docs/src/main/asciidoc/spring-cloud-kubernetes.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-kubernetes.adoc
@@ -5,6 +5,8 @@
 Spring Cloud Kubernetes provide Spring Cloud common interfaces implementations to consume Kubernetes native services.
 The main objective of the projects provided in this repository is to facilitate the integration of Spring Cloud/Spring Boot applications running inside Kubernetes.
 
+include::getting-started.adoc[]
+
 include::discovery-client.adoc[]
 
 include::discovery-kubernetes-native.adoc[]


### PR DESCRIPTION
List all starters in a summary near the beginning of the documentation.
Delete version from the example POM dependencies. Version should be
assigned by the BOM.

Fixes #146
Fixes #326