### PR TITLE
URL Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ buildNumber.properties
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -794,7 +794,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -816,13 +816,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -880,7 +880,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -893,7 +893,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -964,7 +964,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientConfigClientBootstrapConfigurationTests.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientConfigClientBootstrapConfigurationTests.java
@@ -69,7 +69,7 @@ public class KubernetesDiscoveryClientConfigClientBootstrapConfigurationTests {
 		verify(client, atLeast(2)).getInstances("configserver");
 		ConfigClientProperties locator = this.context
 				.getBean(ConfigClientProperties.class);
-		assertEquals("http://fake:8888/", locator.getUri()[0]);
+		assertEquals("https://fake:8888/", locator.getUri()[0]);
 	}
 
 	private void setup(String... env) {

--- a/spring-cloud-kubernetes-examples/kubernetes-circuitbreaker-ribbon-example/greeting-service/src/main/java/org/springframework/cloud/kubernetes/examples/NameService.java
+++ b/spring-cloud-kubernetes-examples/kubernetes-circuitbreaker-ribbon-example/greeting-service/src/main/java/org/springframework/cloud/kubernetes/examples/NameService.java
@@ -40,7 +40,7 @@ public class NameService {
 			@HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "1000") })
 	public String getName(int delay) {
 		return this.restTemplate.getForObject(
-				String.format("http://name-service/name?delay=%d", delay), String.class);
+				String.format("https://name-service/name?delay=%d", delay), String.class);
 	}
 
 	private String getFallbackName(int delay) {

--- a/spring-cloud-kubernetes-examples/kubernetes-circuitbreaker-ribbon-example/readme.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-circuitbreaker-ribbon-example/readme.md
@@ -1,6 +1,6 @@
 ## Kubernetes Circuit Breaker & Load Balancer Example
 
-This example demonstrates how to use [Hystrix circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) and the [Ribbon Load Balancing](http://microservices.io/patterns/client-side-discovery.html). The circuit breaker which is backed with Ribbon will check regularly if the target service is still alive. If this is not loner the case, then a fall back process will be excuted. In our case, the REST `greeting service` which is calling the `name Service` responsible to generate the response message will reply a "fallback message" to the client if the `name service` is not longer replying.
+This example demonstrates how to use [Hystrix circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) and the [Ribbon Load Balancing](https://microservices.io/patterns/client-side-discovery.html). The circuit breaker which is backed with Ribbon will check regularly if the target service is still alive. If this is not loner the case, then a fall back process will be excuted. In our case, the REST `greeting service` which is calling the `name Service` responsible to generate the response message will reply a "fallback message" to the client if the `name service` is not longer replying.
 As the Ribbon Kubernetes client is configured within this example, it will fetch from the Kubernetes API Server, the list of the endpoints available for the name service and loadbalance the request between the IP addresses available
 
 ### Running the example
@@ -39,7 +39,7 @@ minikube service --url greeting-service
 and then call the service using the curl client
 
 ```
-curl http://IP_OR_HOSTNAME/greeting
+curl https://IP_OR_HOSTNAME/greeting
 ```
 
 to get a response as such 
@@ -84,9 +84,9 @@ name-service   172.17.0.5:8080,172.17.0.6:8080   40m
 Here is an example about what you will get
 
 ```
-curl http://IP_OR_HOSTNAME/greeting
+curl https://IP_OR_HOSTNAME/greeting
 Hello from name-service-1652024859-hf3xv!
-curl http://IP_OR_HOSTNAME/greeting
+curl https://IP_OR_HOSTNAME/greeting
 Hello from name-service-1652024859-426kv!
 ...
 ```
@@ -150,7 +150,7 @@ oc get route/greeting-service
 and then call the service using the curl client
 
 ```
-curl http://IP_OR_HOSTNAME/greeting
+curl https://IP_OR_HOSTNAME/greeting
 ```
 
 to get a response as such 
@@ -195,9 +195,9 @@ name-service   172.17.0.2:8080,172.17.0.3:8080   40m
 Here is an example about what you will get
 
 ```
-curl http://IP_OR_HOSTNAME/greeting
+curl https://IP_OR_HOSTNAME/greeting
 Hello from name-service-1-0ss0r!
-curl http://IP_OR_HOSTNAME/greeting
+curl https://IP_OR_HOSTNAME/greeting
 Hello from name-service-1-fblp1!
 ...
 ```

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
@@ -44,13 +44,13 @@ minikube service kubernetes-hello-world --url
 And next you can curl the endpoint using the url returned by the previous command
 
 ``` 
-curl http://IP_OR_HOSTNAME/
+curl https://IP_OR_HOSTNAME/
 ```
 
 then
 
 ``` 
-curl http://IP_OR_HOSTNAME/services
+curl https://IP_OR_HOSTNAME/services
 ```     
 
 Should return you the list of available services discovered by the DiscoveryClient     

--- a/spring-cloud-kubernetes-integration-tests/discovery/tests/src/test/java/org/springframework/cloud/kubernetes/it/ServicesIT.java
+++ b/spring-cloud-kubernetes-integration-tests/discovery/tests/src/test/java/org/springframework/cloud/kubernetes/it/ServicesIT.java
@@ -37,7 +37,7 @@ public class ServicesIT {
 
 	@Test
 	public void testServicesEndpoint() {
-		given().baseUri(String.format("http://%s:%d", HOST, PORT)).get("services").then()
+		given().baseUri(String.format("https://%s:%d", HOST, PORT)).get("services").then()
 				.statusCode(200).body(new StringContains("service-a") {
 					@Override
 					protected boolean evalSubstringOf(String s) {
@@ -48,7 +48,7 @@ public class ServicesIT {
 
 	@Test
 	public void testInstancesEndpoint() {
-		given().baseUri(String.format("http://%s:%d", HOST, PORT))
+		given().baseUri(String.format("https://%s:%d", HOST, PORT))
 				.get("services/discovery-service-a/instances").then().statusCode(200)
 				.body("instanceId", hasSize(1))
 				.body("serviceId", hasItems("discovery-service-a"));

--- a/spring-cloud-kubernetes-integration-tests/istio/src/test/java/org/springframework/cloud/kubernetes/it/ProfilesIT.java
+++ b/spring-cloud-kubernetes-integration-tests/istio/src/test/java/org/springframework/cloud/kubernetes/it/ProfilesIT.java
@@ -35,7 +35,7 @@ public class ProfilesIT {
 
 	@Test
 	public void testProfileEndpoint() {
-		given().baseUri(String.format("http://%s:%d", HOST, PORT)).get("profiles").then()
+		given().baseUri(String.format("https://%s:%d", HOST, PORT)).get("profiles").then()
 				.statusCode(200).body(new StringContains("istio"));
 	}
 

--- a/spring-cloud-kubernetes-integration-tests/simple-configmap/src/test/java/org/springframework/cloud/kubernetes/it/GreetingIT.java
+++ b/spring-cloud-kubernetes-integration-tests/simple-configmap/src/test/java/org/springframework/cloud/kubernetes/it/GreetingIT.java
@@ -39,7 +39,7 @@ public class GreetingIT {
 
 	@Test
 	public void firstTestThatTheDefaultMessageIsReturned() {
-		given().baseUri(String.format("http://%s:%d", HOST, PORT)).get("greeting").then()
+		given().baseUri(String.format("https://%s:%d", HOST, PORT)).get("greeting").then()
 				.statusCode(200).body("message", is("This is a dummy message"));
 	}
 
@@ -48,7 +48,7 @@ public class GreetingIT {
 	public void thenApplyAConfigMapAndEnsureThatTheMessageIsUpdated() {
 		waitForApplicationToReload();
 
-		given().baseUri(String.format("http://%s:%d", HOST, PORT)).get("greeting").then()
+		given().baseUri(String.format("https://%s:%d", HOST, PORT)).get("greeting").then()
 				.statusCode(200)
 				.body("message", is("Hello from Spring Cloud Kubernetes!"));
 	}

--- a/spring-cloud-kubernetes-integration-tests/simple-core/src/test/java/org/springframework/cloud/kubernetes/it/GreetingAndHealthIT.java
+++ b/spring-cloud-kubernetes-integration-tests/simple-core/src/test/java/org/springframework/cloud/kubernetes/it/GreetingAndHealthIT.java
@@ -35,13 +35,13 @@ public class GreetingAndHealthIT {
 
 	@Test
 	public void testGreetingEndpoint() {
-		given().baseUri(String.format("http://%s:%d", HOST, PORT)).get("greeting").then()
+		given().baseUri(String.format("https://%s:%d", HOST, PORT)).get("greeting").then()
 				.statusCode(200).body("message", is("Hello from k8s"));
 	}
 
 	@Test
 	public void testHealthEndpoint() {
-		given().baseUri(String.format("http://%s:%d", HOST, PORT))
+		given().baseUri(String.format("https://%s:%d", HOST, PORT))
 				.contentType("application/json").get("actuator/health").then()
 				.statusCode(200).body("details.kubernetes.details.inside", is(true));
 	}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://arquillian.org/arquillian-cube/ (200) with 1 occurrences could not be migrated:  
   ([https](https://arquillian.org/arquillian-cube/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://%s:%d (UnknownHostException) with 7 occurrences migrated to:  
  https://%s:%d ([https](https://%s:%d) result UnknownHostException).
* [ ] http://IP_OR_HOSTNAME/ (UnknownHostException) with 1 occurrences migrated to:  
  https://IP_OR_HOSTNAME/ ([https](https://IP_OR_HOSTNAME/) result UnknownHostException).
* [ ] http://IP_OR_HOSTNAME/greeting (UnknownHostException) with 6 occurrences migrated to:  
  https://IP_OR_HOSTNAME/greeting ([https](https://IP_OR_HOSTNAME/greeting) result UnknownHostException).
* [ ] http://IP_OR_HOSTNAME/services (UnknownHostException) with 1 occurrences migrated to:  
  https://IP_OR_HOSTNAME/services ([https](https://IP_OR_HOSTNAME/services) result UnknownHostException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://fake:8888/ (UnknownHostException) with 1 occurrences migrated to:  
  https://fake:8888/ ([https](https://fake:8888/) result UnknownHostException).
* [ ] http://name-service/name?delay=%d (UnknownHostException) with 1 occurrences migrated to:  
  https://name-service/name?delay=%d ([https](https://name-service/name?delay=%d) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://EditorConfig.org with 1 occurrences migrated to:  
  https://EditorConfig.org ([https](https://EditorConfig.org) result 200).
* [ ] http://microservices.io/patterns/client-side-discovery.html with 1 occurrences migrated to:  
  https://microservices.io/patterns/client-side-discovery.html ([https](https://microservices.io/patterns/client-side-discovery.html) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 7 occurrences
* http://testapp/greeting with 5 occurrences