### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ buildNumber.properties
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Spring Cloud Kubernetes
 
-[Spring Cloud](http://projects.spring.io/spring-cloud/) integration with [Kubernetes](http://kubernetes.io/)
+[Spring Cloud](https://projects.spring.io/spring-cloud/) integration with [Kubernetes](https://kubernetes.io/)
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes/) ![Apache 2](http://img.shields.io/badge/license-Apache%202-red.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes/) ![Apache 2](https://img.shields.io/badge/license-Apache%202-red.svg)
 
 ### Features
 
@@ -22,11 +22,11 @@
 ### DiscoveryClient for Kubernetes
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes/)
-[![Javadocs](http://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes.svg?color=blue)](http://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes)
+[![Javadocs](https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes.svg?color=blue)](https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes)
 [![Dependency Status](https://www.versioneye.com/java/org.springframework.cloud:spring-cloud-starter-kubernetes/badge?style=flat)](https://www.versioneye.com/java/org.springframework.cloud:spring-cloud-starter-kubernetes/)
 
 
-This project provides an implementation of [Discovery Client](https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java) for [Kubernetes](http://kubernetes.io). This allows you to query Kubernetes endpoints *(see [services](http://kubernetes.io/docs/user-guide/services/))* by name.
+This project provides an implementation of [Discovery Client](https://github.com/spring-cloud/spring-cloud-commons/blob/master/spring-cloud-commons/src/main/java/org/springframework/cloud/client/discovery/DiscoveryClient.java) for [Kubernetes](https://kubernetes.io). This allows you to query Kubernetes endpoints *(see [services](https://kubernetes.io/docs/user-guide/services/))* by name.
 A service is typically exposed by the Kubernetes API server as a collection of endpoints which represent `http`, `https` addresses that a client can
 access from a Spring Boot application running as a pod. This discovery feature is also used by the Spring Cloud Kubernetes Ribbon or Zipkin projects
 to fetch respectively the list of the endpoints defined for an application to be load balanced or the Zipkin servers available to send the traces or spans.
@@ -81,7 +81,7 @@ variables.
 
 #### ConfigMap PropertySource
 
-Kubernetes provides a resource named [ConfigMap](http://kubernetes.io/docs/user-guide/configmap/) to externalize the 
+Kubernetes provides a resource named [ConfigMap](https://kubernetes.io/docs/user-guide/configmap/) to externalize the 
 parameters to pass to your application in the form of key-value pairs or embedded `application.properties|yaml` files.
 The [Spring Cloud Kubernetes Config](./spring-cloud-kubernetes-config) project makes Kubernetes `ConfigMap`s available 
 during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on 
@@ -450,7 +450,7 @@ Notes:
 ### Pod Health Indicator
 
 Spring Boot uses [HealthIndicator](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthIndicator.java) to expose info about the health of an application.
-That makes it really useful for exposing health related information to the user and are also a good fit for use as [readiness probes](http://kubernetes.io/docs/user-guide/production-pods/#liveness-and-readiness-probes-aka-health-checks).
+That makes it really useful for exposing health related information to the user and are also a good fit for use as [readiness probes](https://kubernetes.io/docs/user-guide/production-pods/#liveness-and-readiness-probes-aka-health-checks).
 
 The Kubernetes health indicator which is part of the core module exposes the following info:
 
@@ -476,7 +476,7 @@ within the Kubernetes platform *(e.g. different dev and prod configuration)*.
 ### Ribbon discovery in Kubernetes
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix/)
-[![Javadocs](http://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix.svg?color=blue)](http://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix)
+[![Javadocs](https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix.svg?color=blue)](https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix)
 [![Dependency Status](https://www.versioneye.com/java/org.springframework.cloud:spring-cloud-starter-kubernetes-netflix/badge?style=flat)](https://www.versioneye.com/java/org.springframework.cloud:spring-cloud-starter-kubernetes-netflix/)
 
 Spring Cloud client applications calling a microservice should be interested on relying on a client load-balancing 
@@ -542,7 +542,7 @@ Examples of application that are using Zipkin discovery in Kubernetes:
 ### ConfigMap Archaius Bridge
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-kubernetes-archaius/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/org.springframework.cloud/spring-cloud-kubernetes-archaius/)
-[![Javadocs](http://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-kubernetes-archaius.svg?color=blue)](http://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-kubernetes-archaius)
+[![Javadocs](https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-kubernetes-archaius.svg?color=blue)](https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-kubernetes-archaius)
 [![Dependency Status](https://www.versioneye.com/java/org.springframework.cloud:spring-cloud-kubernetes-archaius/badge?style=flat)](https://www.versioneye.com/java/org.springframework.cloud:spring-cloud-kubernetes-archaius/)
 
 The section [ConfigMap PropertySource](#configmap-propertysource) introduced how to configure a spring boot application via `Kubernetes ConfigMap` containing your configuration properties file.

--- a/spring-cloud-kubernetes-examples/kubernetes-circuitbreaker-ribbon-example/readme.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-circuitbreaker-ribbon-example/readme.md
@@ -1,6 +1,6 @@
 ## Kubernetes Circuit Breaker & Load Balancer Example
 
-This example demonstrates how to use [Hystrix circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) and the [Ribbon Load Balancing](http://microservices.io/patterns/client-side-discovery.html). The circuit breaker which is backed with Ribbon will check regularly if the target service is still alive. If this is not loner the case, then a fall back process will be excuted. In our case, the REST `greeting service` which is calling the `name Service` responsible to generate the response message will reply a "fallback message" to the client if the `name service` is not longer replying.
+This example demonstrates how to use [Hystrix circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) and the [Ribbon Load Balancing](https://microservices.io/patterns/client-side-discovery.html). The circuit breaker which is backed with Ribbon will check regularly if the target service is still alive. If this is not loner the case, then a fall back process will be excuted. In our case, the REST `greeting service` which is calling the `name Service` responsible to generate the response message will reply a "fallback message" to the client if the `name service` is not longer replying.
 As the Ribbon Kubernetes client is configured within this example, it will fetch from the Kubernetes API Server, the list of the endpoints available for the name service and loadbalance the request between the IP addresses available
 
 ### Running the example

--- a/spring-cloud-kubernetes-examples/kubernetes-zipkin-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-zipkin-example/README.md
@@ -42,7 +42,7 @@ To deploy the Zipkin server and store the traces under a MySQL server, execute t
 and next to deploy the Zipkin application
 
 ```
-kubectl create -f http://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-kubernetes.yml
+kubectl create -f https://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-kubernetes.yml
 
 cat << EOF | kubectl create -f -
 kind: PersistentVolume
@@ -116,7 +116,7 @@ oc policy add-role-to-user view --serviceaccount=default
 To deploy the Zipkin server and store the traces under a MySQL server, execute the following commands to deploy the Zipkin application
 
 ```
-oc create -f http://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-openshift.yml
+oc create -f https://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-openshift.yml
 oc delete pvc/mysql-data
 
 cat << EOF | oc create -f - 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://img.shields.io/badge/license-Apache%202-red.svg with 1 occurrences migrated to:  
  https://img.shields.io/badge/license-Apache%202-red.svg ([https](https://img.shields.io/badge/license-Apache%202-red.svg) result 200).
* [ ] http://kubernetes.io with 1 occurrences migrated to:  
  https://kubernetes.io ([https](https://kubernetes.io) result 200).
* [ ] http://kubernetes.io/ with 1 occurrences migrated to:  
  https://kubernetes.io/ ([https](https://kubernetes.io/) result 200).
* [ ] http://microservices.io/patterns/client-side-discovery.html with 1 occurrences migrated to:  
  https://microservices.io/patterns/client-side-discovery.html ([https](https://microservices.io/patterns/client-side-discovery.html) result 200).
* [ ] http://projects.spring.io/spring-cloud/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* [ ] http://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-kubernetes.yml with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-kubernetes.yml ([https](https://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-kubernetes.yml) result 200).
* [ ] http://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-openshift.yml with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-openshift.yml ([https](https://repo1.maven.org/maven2/io/fabric8/zipkin/zipkin-starter-minimal/0.1.9/zipkin-starter-minimal-0.1.9-openshift.yml) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* [ ] http://kubernetes.io/docs/user-guide/configmap/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/configmap/ ([https](https://kubernetes.io/docs/user-guide/configmap/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/production-pods/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/production-pods/ ([https](https://kubernetes.io/docs/user-guide/production-pods/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/services/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/services/ ([https](https://kubernetes.io/docs/user-guide/services/) result 301).
* [ ] http://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-kubernetes-archaius.svg?color=blue with 1 occurrences migrated to:  
  https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-kubernetes-archaius.svg?color=blue ([https](https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-kubernetes-archaius.svg?color=blue) result 303).
* [ ] http://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix.svg?color=blue with 1 occurrences migrated to:  
  https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix.svg?color=blue ([https](https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix.svg?color=blue) result 303).
* [ ] http://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes.svg?color=blue with 1 occurrences migrated to:  
  https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes.svg?color=blue ([https](https://www.javadoc.io/badge/org.springframework.cloud/spring-cloud-starter-kubernetes.svg?color=blue) result 303).
* [ ] http://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-kubernetes-archaius with 1 occurrences migrated to:  
  https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-kubernetes-archaius ([https](https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-kubernetes-archaius) result 303).
* [ ] http://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes with 1 occurrences migrated to:  
  https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes ([https](https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes) result 303).
* [ ] http://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix with 1 occurrences migrated to:  
  https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix ([https](https://www.javadoc.io/doc/org.springframework.cloud/spring-cloud-starter-kubernetes-netflix) result 303).

# Ignored
These URLs were intentionally ignored.

* http://IP_OR_HOSTNAME/ with 1 occurrences
* http://IP_OR_HOSTNAME/greeting with 6 occurrences
* http://localhost with 2 occurrences
* http://localhost/api with 2 occurrences
* http://localhost/db with 2 occurrences
* http://localhost:%d/api/farewell with 3 occurrences
* http://localhost:%d/api/greeting with 4 occurrences
* http://name-service/name?delay=%d with 1 occurrences
* http://testapp/greeting with 5 occurrences
* http://zipkinserver with 1 occurrences