### PR TITLE
README update for ConfigMap reload sample

### DIFF
--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/rb.yml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/rb.yml
@@ -1,11 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: config-reader
+  name: pod-reader
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: view
+  kind: Role
+  name: pod-reader
 subjects:
   - kind: ServiceAccount
     name: config-reader

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/rb.yml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/rb.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: config-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: config-reader
+    namespace: default

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/role.yml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/role.yml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods","configmaps"]
+    verbs: ["get", "watch", "list"]

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/sa.yml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/src/k8s/sa.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: config-reader
+  namespace: default


### PR DESCRIPTION
1. Fixed small typos
2. Removed notes about Spring Boot liveness and readiness check related
to Fabric8 since that issue has been resolved and is working as expected
3. Added sample configuration files for K8s RBAC set up required for the
example to work
4. Added section about how to setup RBAC config