### PR TITLE
Enhance Hystrix ThreadPool mode so that it can correctly pass Istio's call chain headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 		<spring-cloud-netflix.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-config.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-config.version>
 
+
 		<!-- Maven Plugin Versions -->
 		<maven-compiler-plugin.version>3.5</maven-compiler-plugin.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -74,8 +75,11 @@
 		<maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
 		<fabric8.maven.plugin.version>3.5.37</fabric8.maven.plugin.version>
 		<groovy.version>2.4.12</groovy.version>
+		<commons-lang3.version>3.8.1</commons-lang3.version>
 		<restassured.version>3.0.2</restassured.version>
 		<spock-spring.version>1.1-groovy-2.4</spock-spring.version>
+		<feign-core.version>9.7.0</feign-core.version>
+		<transmittable-thread-local.version>2.10.2</transmittable-thread-local.version>
 
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failsOnViolation>true
@@ -135,6 +139,12 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>${commons-lang3.version}</version>
+			</dependency>
+
+			<dependency>
 				<groupId>org.spockframework</groupId>
 				<artifactId>spock-spring</artifactId>
 				<version>${spock-spring.version}</version>
@@ -146,6 +156,16 @@
 				<artifactId>spring-cloud-test-support</artifactId>
 				<version>${spring-cloud-commons.version}</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.github.openfeign</groupId>
+				<artifactId>feign-core</artifactId>
+				<version>${feign-core.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.alibaba</groupId>
+				<artifactId>transmittable-thread-local</artifactId>
+				<version>${transmittable-thread-local.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-kubernetes-istio/pom.xml
+++ b/spring-cloud-kubernetes-istio/pom.xml
@@ -36,6 +36,36 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-commons</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.hystrix</groupId>
+			<artifactId>hystrix-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>transmittable-thread-local</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/IstioConstants.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/IstioConstants.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio;
+
+/**
+ * the IstioConstants description.
+ *
+ * @author wuzishu
+ */
+public final class IstioConstants {
+
+	private IstioConstants() {
+	}
+
+	/**
+	 * The constant X_REQUEST_ID.
+	 */
+	public static final String X_REQUEST_ID = "x-request-id";
+
+	/**
+	 * The constant X_B3_TRACEID.
+	 */
+	public static final String X_B3_TRACEID = "x-b3-traceid";
+
+	/**
+	 * The constant X_B3_SPANID.
+	 */
+	public static final String X_B3_SPANID = "x-b3-spanid";
+
+	/**
+	 * The constant X_B3_PARENTSPANID.
+	 */
+	public static final String X_B3_PARENTSPANID = "x-b3-parentspanid";
+
+	/**
+	 * The constant X_B3_SAMPLED.
+	 */
+	public static final String X_B3_SAMPLED = "x-b3-sampled";
+
+	/**
+	 * The constant X_B3_FLAGS.
+	 */
+	public static final String X_B3_FLAGS = "x-b3-flags";
+
+	/**
+	 * The constant X_OT_SPAN_CONTEXT.
+	 */
+	public static final String X_OT_SPAN_CONTEXT = "x-ot-span-context";
+
+	/**
+	 * The constant USER_AGENT.
+	 */
+	public static final String USER_AGENT = "user-agent";
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/IstioRibbonAutoConfiguration.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/IstioRibbonAutoConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
+import org.springframework.cloud.kubernetes.istio.trace.HeaderPropagationClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Set the interceptor for the RestTemplate to pass the Istio call chain Headers.
+ *
+ * @author wuzishu
+ * @see org.springframework.cloud.kubernetes.istio.trace.HeaderPropagationClientHttpRequestInterceptor
+ * @see org.springframework.http.client.ClientHttpRequestInterceptor
+ */
+@ConditionalOnClass(RestTemplate.class)
+@ConditionalOnBean(LoadBalancerClient.class)
+public class IstioRibbonAutoConfiguration {
+
+	@LoadBalanced
+	@Autowired(required = false)
+	private List<RestTemplate> restTemplates = Collections.emptyList();
+
+	@Autowired(required = false)
+	private HeaderPropagationClientHttpRequestInterceptor interceptor;
+
+	@PostConstruct
+	public void RestTemplateCustom() {
+		if (interceptor != null) {
+			for (RestTemplate restTemplate : restTemplates) {
+				List<ClientHttpRequestInterceptor> interceptors = restTemplate
+						.getInterceptors();
+				interceptors.add(interceptor);
+				restTemplate.setInterceptors(interceptors);
+			}
+		}
+
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/FeignPropagationRequestInterceptor.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/FeignPropagationRequestInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.util.Arrays;
+import java.util.List;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.kubernetes.istio.IstioConstants;
+
+/**
+ * the FeignPropagationRequestInterceptor description.
+ *
+ * @author wuzishu
+ */
+@ConditionalOnClass(RequestInterceptor.class)
+@ConditionalOnProperty(value = "spring.cloud.istio.enabled", matchIfMissing = true)
+public class FeignPropagationRequestInterceptor implements RequestInterceptor {
+
+	private static final Logger LOG = LoggerFactory
+			.getLogger(FeignPropagationRequestInterceptor.class);
+
+	private static List<String> HEADERS = Arrays.asList(IstioConstants.X_REQUEST_ID,
+			IstioConstants.X_B3_TRACEID, IstioConstants.X_B3_SPANID,
+			IstioConstants.X_B3_PARENTSPANID, IstioConstants.X_B3_SAMPLED,
+			IstioConstants.X_B3_FLAGS, IstioConstants.X_OT_SPAN_CONTEXT,
+			IstioConstants.USER_AGENT);
+
+	@Override
+	public void apply(RequestTemplate requestTemplate) {
+		for (String header : HEADERS) {
+			String value = HeaderPropagationHolder.get(header);
+			if (StringUtils.isNotBlank(value)) {
+				requestTemplate.header(header, value);
+			}
+		}
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HeaderPropagationClientHttpRequestInterceptor.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HeaderPropagationClientHttpRequestInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+/**
+ * Define the ClientHttpRequestInterceptor interceptor to pass the Istio request headers.
+ *
+ * @author wuzishu
+ * @see org.springframework.cloud.kubernetes.istio.trace.HeaderPropagationHolder
+ */
+@ConditionalOnProperty(value = "spring.cloud.istio.enabled", matchIfMissing = true)
+public class HeaderPropagationClientHttpRequestInterceptor
+		implements ClientHttpRequestInterceptor {
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest httpRequest, byte[] bytes,
+			ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
+		HttpHeaders headers = httpRequest.getHeaders();
+		for (Map.Entry<String, String> entry : HeaderPropagationHolder.entries()) {
+			if (StringUtils.isNotBlank(entry.getKey())
+					&& StringUtils.isNotBlank(entry.getValue())) {
+				headers.set(entry.getKey(), entry.getValue());
+			}
+		}
+		return clientHttpRequestExecution.execute(httpRequest, bytes);
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HeaderPropagationHolder.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HeaderPropagationHolder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.alibaba.ttl.TransmittableThreadLocal;
+
+/**
+ * Define TransmittableThreadLocal thread safety variable, support thread pool to pass
+ * variables, no variable value error due to thread multiplexing.
+ *
+ * @author wuzishu
+ * @see com.alibaba.ttl.TransmittableThreadLocal
+ */
+public final class HeaderPropagationHolder {
+
+	private static final TransmittableThreadLocal<Map<String, String>> headers = new TransmittableThreadLocal<Map<String, String>>() {
+		@Override
+		protected Map<String, String> initialValue() {
+			return new HashMap<>();
+		}
+	};
+
+	private HeaderPropagationHolder() {
+	}
+
+	/**
+	 * Sync.
+	 * @param all the all
+	 */
+	public static void sync(Map<String, String> all) {
+		headers.set(all);
+	}
+
+	/**
+	 * Put.
+	 * @param header header name.
+	 * @param value header value.
+	 */
+	public static void put(String header, String value) {
+		Map<String, String> map = headers.get();
+		if (map == null) {
+			map = new HashMap<>();
+		}
+		map.put(header, value);
+		headers.set(map);
+	}
+
+	/**
+	 * Get string.
+	 * @param header header name
+	 * @return the string
+	 */
+	public static String get(String header) {
+		Map<String, String> map = headers.get();
+		if (map == null) {
+			map = new HashMap<>();
+		}
+		return map.get(header);
+	}
+
+	/**
+	 * Entries set.
+	 * @return the set
+	 */
+	public static Set<Map.Entry<String, String>> entries() {
+		Map<String, String> map = headers.get();
+		if (map == null) {
+			map = new HashMap<>();
+		}
+		return map.entrySet();
+	}
+
+	/**
+	 * All map.
+	 * @return the map
+	 */
+	public static Map<String, String> all() {
+		Map<String, String> map = headers.get();
+		if (map == null) {
+			map = new HashMap<>();
+		}
+		Map<String, String> treeMap = new TreeMap<>(
+				Comparator.comparing(String::toLowerCase));
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			treeMap.put(entry.getKey(), entry.getValue());
+		}
+		return Collections.unmodifiableMap(treeMap);
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HeaderPropagationRequestFilter.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HeaderPropagationRequestFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Define the RequestFilter and set the TraceHeader of Istio to the
+ * HeaderPropagationHolder, which is provided to the thread pool and can be passed to the
+ * next call.
+ *
+ * @author wuzishu
+ * @see org.springframework.web.filter.OncePerRequestFilter
+ * @see org.springframework.cloud.kubernetes.istio.trace.HeaderPropagationHolder
+ */
+
+public abstract class HeaderPropagationRequestFilter extends OncePerRequestFilter {
+
+	private final List<String> headersToPropagate;
+
+	/**
+	 * Instantiates a new Header propagation request filter.
+	 * @param headersToPropagate the headers to propagate
+	 */
+	public HeaderPropagationRequestFilter(List<String> headersToPropagate) {
+		this.headersToPropagate = headersToPropagate;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, FilterChain filterChain)
+			throws ServletException, IOException {
+		for (String header : headersToPropagate) {
+			String value = httpServletRequest.getHeader(header);
+			if (StringUtils.isNotBlank(value)) {
+				HeaderPropagationHolder.put(header, value);
+			}
+		}
+		filterChain.doFilter(httpServletRequest, httpServletResponse);
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HystrixConcurrencyStategyBeanFactoryPostProcessor.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/HystrixConcurrencyStategyBeanFactoryPostProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * Use BeanFactoryProcessor to customize Hystrix's thread pool to support Istio's call
+ * chain headers.
+ *
+ * @author wuzishu
+ * @see org.springframework.beans.factory.config.BeanFactoryPostProcessor
+ * @see org.springframework.cloud.kubernetes.istio.trace.ThreadLocalHystrixConcurrencyStrategy
+ * @see com.netflix.hystrix.strategy.HystrixPlugins
+ */
+@ConditionalOnClass(HystrixConcurrencyStrategy.class)
+@ConditionalOnProperty(value = "spring.cloud.istio.enabled", matchIfMissing = true)
+public class HystrixConcurrencyStategyBeanFactoryPostProcessor
+		implements BeanFactoryPostProcessor {
+
+	@Override
+	public void postProcessBeanFactory(
+			ConfigurableListableBeanFactory configurableListableBeanFactory)
+			throws BeansException {
+		HystrixPlugins.getInstance()
+				.registerConcurrencyStrategy(new ThreadLocalHystrixConcurrencyStrategy());
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/IstioHeaderPropagatoinRequestFilter.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/IstioHeaderPropagatoinRequestFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.kubernetes.istio.IstioConstants;
+
+/**
+ * Inherited from HeaderPropagationRequestFilter and set the headers of Istio that need to
+ * be passed.
+ *
+ * @author wuzishu
+ * @see org.springframework.cloud.kubernetes.istio.trace.HeaderPropagationRequestFilter
+ */
+@ConditionalOnProperty(value = "spring.cloud.istio.enabled", matchIfMissing = true)
+public class IstioHeaderPropagatoinRequestFilter extends HeaderPropagationRequestFilter {
+
+	private static List<String> HEADERS = Arrays.asList(IstioConstants.X_REQUEST_ID,
+			IstioConstants.X_B3_TRACEID, IstioConstants.X_B3_SPANID,
+			IstioConstants.X_B3_PARENTSPANID, IstioConstants.X_B3_SAMPLED,
+			IstioConstants.X_B3_FLAGS, IstioConstants.X_OT_SPAN_CONTEXT,
+			IstioConstants.USER_AGENT);
+
+	/**
+	 * Instantiates a new Istio header propagatoin request filter.
+	 */
+	public IstioHeaderPropagatoinRequestFilter() {
+		super(HEADERS);
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/ThreadLocalHystrixConcurrencyStrategy.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/ThreadLocalHystrixConcurrencyStrategy.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+import com.netflix.hystrix.util.PlatformSpecific;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Customize the thread pool of Hystrix thread pool mode, enabling it to pass Istio call
+ * chain headers without Header value error.
+ *
+ * @author wuzishu
+ * @see com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy
+ * @see org.springframework.cloud.kubernetes.istio.trace.ThreadLocalThreadPoolExecutor
+ */
+@ConditionalOnClass(HystrixConcurrencyStrategy.class)
+@ConditionalOnProperty(value = "spring.cloud.istio.enabled", matchIfMissing = true)
+@Order(1)
+public class ThreadLocalHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
+
+	private final static Logger logger = LoggerFactory
+			.getLogger(ThreadLocalHystrixConcurrencyStrategy.class);
+
+	public ThreadLocalHystrixConcurrencyStrategy() {
+
+	}
+
+	@Override
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixProperty<Integer> corePoolSize,
+			HystrixProperty<Integer> maximumPoolSize,
+			HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+			BlockingQueue<Runnable> workQueue) {
+		return this.doGetThreadPool(threadPoolKey, corePoolSize, maximumPoolSize,
+				keepAliveTime, unit, workQueue);
+	}
+
+	@Override
+	public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey,
+			HystrixThreadPoolProperties threadPoolProperties) {
+		return this.doGetThreadPool(threadPoolKey, threadPoolProperties);
+	}
+
+	private ThreadPoolExecutor doGetThreadPool(final HystrixThreadPoolKey threadPoolKey,
+			HystrixProperty<Integer> corePoolSize,
+			HystrixProperty<Integer> maximumPoolSize,
+			HystrixProperty<Integer> keepAliveTime, TimeUnit unit,
+			BlockingQueue<Runnable> workQueue) {
+		final ThreadFactory threadFactory = getThreadFactory(threadPoolKey);
+
+		final int dynamicCoreSize = corePoolSize.get();
+		final int dynamicMaximumSize = maximumPoolSize.get();
+
+		if (dynamicCoreSize > dynamicMaximumSize) {
+			logger.error("Hystrix ThreadPool configuration at startup for : "
+					+ threadPoolKey.name() + " is trying to set coreSize = "
+					+ dynamicCoreSize + " and maximumSize = " + dynamicMaximumSize
+					+ ".  Maximum size will be set to " + dynamicCoreSize
+					+ ", the coreSize value, since it must be equal to or greater than the coreSize value");
+			return new ThreadLocalThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize,
+					keepAliveTime.get(), unit, workQueue, threadFactory);
+		}
+		else {
+			return new ThreadLocalThreadPoolExecutor(dynamicCoreSize, dynamicMaximumSize,
+					keepAliveTime.get(), unit, workQueue, threadFactory);
+		}
+	}
+
+	private ThreadPoolExecutor doGetThreadPool(final HystrixThreadPoolKey threadPoolKey,
+			HystrixThreadPoolProperties threadPoolProperties) {
+		final ThreadFactory threadFactory = getThreadFactory(threadPoolKey);
+
+		final boolean allowMaximumSizeToDivergeFromCoreSize = threadPoolProperties
+				.getAllowMaximumSizeToDivergeFromCoreSize().get();
+		final int dynamicCoreSize = threadPoolProperties.coreSize().get();
+		final int keepAliveTime = threadPoolProperties.keepAliveTimeMinutes().get();
+		final int maxQueueSize = threadPoolProperties.maxQueueSize().get();
+		final BlockingQueue<Runnable> workQueue = getBlockingQueue(maxQueueSize);
+
+		if (allowMaximumSizeToDivergeFromCoreSize) {
+			final int dynamicMaximumSize = threadPoolProperties.maximumSize().get();
+			if (dynamicCoreSize > dynamicMaximumSize) {
+				logger.error("Hystrix ThreadPool configuration at startup for : "
+						+ threadPoolKey.name() + " is trying to set coreSize = "
+						+ dynamicCoreSize + " and maximumSize = " + dynamicMaximumSize
+						+ ".  Maximum size will be set to " + dynamicCoreSize
+						+ ", the coreSize value, since it must be equal to or greater than the coreSize value");
+				return new ThreadLocalThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize,
+						keepAliveTime, TimeUnit.MINUTES, workQueue, threadFactory);
+			}
+			else {
+				return new ThreadLocalThreadPoolExecutor(dynamicCoreSize,
+						dynamicMaximumSize, keepAliveTime, TimeUnit.MINUTES, workQueue,
+						threadFactory);
+			}
+		}
+		else {
+			return new ThreadLocalThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize,
+					keepAliveTime, TimeUnit.MINUTES, workQueue, threadFactory);
+		}
+	}
+
+	private static ThreadFactory getThreadFactory(
+			final HystrixThreadPoolKey threadPoolKey) {
+		if (!PlatformSpecific.isAppEngineStandardEnvironment()) {
+			return new ThreadFactory() {
+				private final AtomicInteger threadNumber = new AtomicInteger(0);
+
+				@Override
+				public Thread newThread(Runnable r) {
+					Thread thread = new Thread(r, "hystrix-" + threadPoolKey.name() + "-"
+							+ threadNumber.incrementAndGet());
+					thread.setDaemon(true);
+					return thread;
+				}
+
+			};
+		}
+		else {
+			return PlatformSpecific.getAppEngineThreadFactory();
+		}
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/ThreadLocalThreadPoolExecutor.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/trace/ThreadLocalThreadPoolExecutor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.istio.trace;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.alibaba.ttl.TtlRunnable;
+
+/**
+ * Custom ThreadPoolExecutor implements thread pool context ThreadLocal variable passing.
+ *
+ * @author wuzishu
+ * @see java.util.concurrent.ThreadPoolExecutor
+ * @see com.alibaba.ttl.TtlRunnable
+ */
+public class ThreadLocalThreadPoolExecutor extends ThreadPoolExecutor {
+
+	private static final RejectedExecutionHandler defaultHandler = new AbortPolicy();
+
+	public ThreadLocalThreadPoolExecutor(int corePoolSize, int maximumPoolSize,
+			long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
+		super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+	}
+
+	public ThreadLocalThreadPoolExecutor(int corePoolSize, int maximumPoolSize,
+			long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue,
+			ThreadFactory threadFactory) {
+		super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue,
+				threadFactory, defaultHandler);
+	}
+
+	@Override
+	public void execute(Runnable command) {
+		super.execute(TtlRunnable.get(command));
+	}
+
+}

--- a/spring-cloud-kubernetes-istio/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-kubernetes-istio/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,10 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.kubernetes.istio.IstioAutoConfiguration
+org.springframework.cloud.kubernetes.istio.IstioAutoConfiguration,\
+org.springframework.cloud.kubernetes.istio.IstioRibbonAutoConfiguration,\
+org.springframework.cloud.kubernetes.istio.trace.IstioHeaderPropagatoinRequestFilter,\
+org.springframework.cloud.kubernetes.istio.trace.HeaderPropagationClientHttpRequestInterceptor,\
+org.springframework.cloud.kubernetes.istio.trace.FeignPropagationRequestInterceptor,\
+org.springframework.cloud.kubernetes.istio.trace.ThreadLocalHystrixConcurrencyStrategy,\
+org.springframework.cloud.kubernetes.istio.trace.HystrixConcurrencyStategyBeanFactoryPostProcessor
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.kubernetes.istio.IstioBootstrapConfiguration


### PR DESCRIPTION
Enhance Hystrix ThreadPool mode so that it can correctly pass Istio's call chain headers, and set the RestTemplate interceptor to intercept ordinary Http requests, providing the ThreadPoolHolder operation class to manually synchronize custom thread pool variables.

Use the effect to string the entire call chain.
![image](https://user-images.githubusercontent.com/6405415/59740656-511dbb80-929b-11e9-902b-0eadcaa568ea.png)
![image](https://user-images.githubusercontent.com/6405415/59740670-5e3aaa80-929b-11e9-92e8-dad76d04e66b.png)
