### PR TITLE
Extracted catalog watch auto-configuration.

### DIFF
--- a/docs/src/main/asciidoc/discovery-client.adoc
+++ b/docs/src/main/asciidoc/discovery-client.adoc
@@ -55,7 +55,3 @@ spring.cloud.kubernetes.discovery.enabled=false
 
 Some Spring Cloud components use the `DiscoveryClient` in order to obtain information about the local service instance. For
 this to work, you need to align the Kubernetes service name with the `spring.application.name` property.
-
-Spring Cloud Kubernetes can also watch the Kubernetes service catalog for changes and update the
-`DiscoveryClient` implementation accordingly.  In order to enable this functionality you need to add
-`@EnableScheduling` on a configuration class in your application.

--- a/docs/src/main/asciidoc/discovery-client.adoc
+++ b/docs/src/main/asciidoc/discovery-client.adoc
@@ -55,3 +55,7 @@ spring.cloud.kubernetes.discovery.enabled=false
 
 Some Spring Cloud components use the `DiscoveryClient` in order to obtain information about the local service instance. For
 this to work, you need to align the Kubernetes service name with the `spring.application.name` property.
+
+Spring Cloud Kubernetes can also watch the Kubernetes service catalog for changes and update the
+`DiscoveryClient` implementation accordingly.  In order to enable this functionality you need to add
+`@EnableScheduling` on a configuration class in your application.

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchAutoConfiguration.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchAutoConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.discovery;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.client.ConditionalOnDiscoveryEnabled;
+import org.springframework.cloud.kubernetes.KubernetesAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Auto configuration for catalog watcher.
+ *
+ * @author Tim Ysewyn
+ */
+@Configuration
+@EnableScheduling
+@ConditionalOnDiscoveryEnabled
+@ConditionalOnProperty(name = "spring.cloud.kubernetes.enabled", matchIfMissing = true)
+@AutoConfigureAfter({ KubernetesAutoConfiguration.class })
+public class KubernetesCatalogWatchAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = "spring.cloud.kubernetes.discovery.catalog-services-watch.enabled", matchIfMissing = true)
+	public KubernetesCatalogWatch kubernetesCatalogWatch(KubernetesClient client) {
+		return new KubernetesCatalogWatch(client);
+	}
+
+}

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchAutoConfiguration.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.cloud.client.ConditionalOnDiscoveryEnabled;
 import org.springframework.cloud.kubernetes.KubernetesAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Auto configuration for catalog watcher.
@@ -33,7 +32,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * @author Tim Ysewyn
  */
 @Configuration
-@EnableScheduling
 @ConditionalOnDiscoveryEnabled
 @ConditionalOnProperty(name = "spring.cloud.kubernetes.enabled", matchIfMissing = true)
 @AutoConfigureAfter({ KubernetesAutoConfiguration.class })

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.CommonsClientAutoConfiguration;
+import org.springframework.cloud.client.ConditionalOnDiscoveryEnabled;
 import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 import org.springframework.cloud.kubernetes.registry.KubernetesRegistration;
 import org.springframework.cloud.kubernetes.registry.KubernetesServiceRegistry;
@@ -32,8 +33,10 @@ import org.springframework.context.annotation.Configuration;
  * Auto configuration for discovery clients.
  *
  * @author Mauricio Salatino
+ * @author Tim Ysewyn
  */
 @Configuration
+@ConditionalOnDiscoveryEnabled
 @ConditionalOnProperty(name = "spring.cloud.kubernetes.enabled", matchIfMissing = true)
 @AutoConfigureBefore({ SimpleDiscoveryClientAutoConfiguration.class,
 		CommonsClientAutoConfiguration.class })
@@ -81,13 +84,6 @@ public class KubernetesDiscoveryClientAutoConfiguration {
 	@Bean
 	public KubernetesDiscoveryProperties getKubernetesDiscoveryProperties() {
 		return new KubernetesDiscoveryProperties();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	@ConditionalOnProperty(name = "spring.cloud.kubernetes.discovery.catalog-services-watch.enabled", matchIfMissing = true)
-	public KubernetesCatalogWatch kubernetesCatalogWatch(KubernetesClient client) {
-		return new KubernetesCatalogWatch(client);
 	}
 
 }

--- a/spring-cloud-kubernetes-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-kubernetes-discovery/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.kubernetes.discovery.KubernetesCatalogWatchAutoConfiguration, \
 org.springframework.cloud.kubernetes.discovery.KubernetesDiscoveryClientAutoConfiguration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.kubernetes.discovery.KubernetesDiscoveryClientConfigClientBootstrapConfiguration

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogServicesWatchConfigurationTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogServicesWatchConfigurationTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Oleg Vyukov
+ * @author Tim Ysewyn
  */
 public class KubernetesCatalogServicesWatchConfigurationTest {
 
@@ -57,6 +58,12 @@ public class KubernetesCatalogServicesWatchConfigurationTest {
 	}
 
 	@Test
+	public void kubernetesCatalogWatchWhenServiceDiscoveryDisabled() throws Exception {
+		setup("spring.cloud.discovery.enabled=false");
+		assertThat(this.context.containsBean("kubernetesCatalogWatch")).isFalse();
+	}
+
+	@Test
 	public void kubernetesCatalogWatchDefaultEnabled() throws Exception {
 		setup();
 		assertThat(this.context.containsBean("kubernetesCatalogWatch")).isTrue();
@@ -66,6 +73,7 @@ public class KubernetesCatalogServicesWatchConfigurationTest {
 		this.context = new SpringApplicationBuilder(
 				PropertyPlaceholderAutoConfiguration.class,
 				KubernetesClientTestConfiguration.class,
+				KubernetesCatalogWatchAutoConfiguration.class,
 				KubernetesDiscoveryClientAutoConfiguration.class)
 						.web(WebApplicationType.NONE).properties(env).run();
 	}

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfigurationPropertiesTests.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientAutoConfigurationPropertiesTests.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Ryan Dawson
+ * @author Tim Ysewyn
  */
 public class KubernetesDiscoveryClientAutoConfigurationPropertiesTests {
 
@@ -54,6 +55,13 @@ public class KubernetesDiscoveryClientAutoConfigurationPropertiesTests {
 	@Test
 	public void kubernetesDiscoveryWhenKubernetesDisabled() throws Exception {
 		setup("spring.cloud.kubernetes.enabled=false");
+		assertThat(this.context.getBeanNamesForType(KubernetesDiscoveryClient.class))
+				.isEmpty();
+	}
+
+	@Test
+	public void kubernetesDiscoveryWhenDiscoveryDisabled() throws Exception {
+		setup("spring.cloud.discovery.enabled=false");
 		assertThat(this.context.getBeanNamesForType(KubernetesDiscoveryClient.class))
 				.isEmpty();
 	}


### PR DESCRIPTION
Needed in order to have that bean running in the correct application context when SC Config discovery is enabled.
Also fixes a bug where Kubernetes discovery was enabled when discovery was disabled with `spring.cloud.kubernetes.enabled=false`.
Relates to spring-cloud/spring-cloud-config#1229