### PR TITLE
restart endpoint does not need to be enabled when refresh is used by …

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.util.Assert;
 
 /**
  * Definition of beans needed for the automatic reload of configuration.
@@ -110,9 +111,11 @@ public class ConfigReloadAutoConfiguration {
 		@ConditionalOnMissingBean
 		public ConfigurationUpdateStrategy configurationUpdateStrategy(
 				ConfigReloadProperties properties, ConfigurableApplicationContext ctx,
-				RestartEndpoint restarter, ContextRefresher refresher) {
+				@Autowired(required = false) RestartEndpoint restarter,
+				ContextRefresher refresher) {
 			switch (properties.getStrategy()) {
 			case RESTART_CONTEXT:
+				Assert.notNull(restarter, "Restart endpoint is not enabled");
 				return new ConfigurationUpdateStrategy(properties.getStrategy().name(),
 						restarter::restart);
 			case REFRESH:


### PR DESCRIPTION
…default fixes gh-402. 

resubmitted, PR is raised against 1.0.x