### PR TITLE
Add namespace information to service instance metadata

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import static java.util.stream.Collectors.toMap;
+import static org.springframework.cloud.kubernetes.discovery.KubernetesServiceInstance.NAMESPACE_METADAT_KEY;
 
 /**
  * Kubeneretes implementation of {@link DiscoveryClient}.
@@ -151,6 +152,10 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 						log.debug("Adding port metadata: " + portMetadata);
 					}
 					endpointMetadata.putAll(portMetadata);
+				}
+
+				if (this.properties.isAllNamespaces()) {
+					endpointMetadata.put(NAMESPACE_METADAT_KEY, namespace);
 				}
 
 				List<EndpointAddress> addresses = s.getAddresses();

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -41,7 +41,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import static java.util.stream.Collectors.toMap;
-import static org.springframework.cloud.kubernetes.discovery.KubernetesServiceInstance.NAMESPACE_METADAT_KEY;
+import static org.springframework.cloud.kubernetes.discovery.KubernetesServiceInstance.NAMESPACE_METADATA_KEY;
 
 /**
  * Kubeneretes implementation of {@link DiscoveryClient}.
@@ -155,7 +155,7 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 				}
 
 				if (this.properties.isAllNamespaces()) {
-					endpointMetadata.put(NAMESPACE_METADAT_KEY, namespace);
+					endpointMetadata.put(NAMESPACE_METADATA_KEY, namespace);
 				}
 
 				List<EndpointAddress> addresses = s.getAddresses();

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstance.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstance.java
@@ -31,6 +31,11 @@ import org.springframework.cloud.client.ServiceInstance;
  */
 public class KubernetesServiceInstance implements ServiceInstance {
 
+	/**
+	 * Key of the namespace metadata.
+	 */
+	public static final String NAMESPACE_METADAT_KEY = "k8s_namespace";
+
 	private static final String HTTP_PREFIX = "http";
 
 	private static final String HTTPS_PREFIX = "https";
@@ -116,6 +121,10 @@ public class KubernetesServiceInstance implements ServiceInstance {
 	@Override
 	public String getScheme() {
 		return isSecure() ? HTTPS_PREFIX : HTTP_PREFIX;
+	}
+
+	public String getNamespace() {
+		return this.metadata != null ? this.metadata.get(NAMESPACE_METADAT_KEY) : null;
 	}
 
 }

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstance.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstance.java
@@ -34,7 +34,7 @@ public class KubernetesServiceInstance implements ServiceInstance {
 	/**
 	 * Key of the namespace metadata.
 	 */
-	public static final String NAMESPACE_METADAT_KEY = "k8s_namespace";
+	public static final String NAMESPACE_METADATA_KEY = "k8s_namespace";
 
 	private static final String HTTP_PREFIX = "http";
 
@@ -124,7 +124,7 @@ public class KubernetesServiceInstance implements ServiceInstance {
 	}
 
 	public String getNamespace() {
-		return this.metadata != null ? this.metadata.get(NAMESPACE_METADAT_KEY) : null;
+		return this.metadata != null ? this.metadata.get(NAMESPACE_METADATA_KEY) : null;
 	}
 
 }

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClientTest.java
@@ -97,52 +97,6 @@ public class KubernetesDiscoveryClientTest {
 				.andReturn(200, service).always();
 
 		final KubernetesDiscoveryProperties properties = new KubernetesDiscoveryProperties();
-		properties.setAllNamespaces(true);
-
-		final DiscoveryClient discoveryClient = new KubernetesDiscoveryClient(mockClient,
-				properties, KubernetesClient::services,
-				new DefaultIsServicePortSecureResolver(properties));
-
-		final List<ServiceInstance> instances = discoveryClient.getInstances("endpoint");
-
-		assertThat(instances).hasSize(2);
-		assertThat(instances).filteredOn(s -> s.getHost().equals("ip1") && !s.isSecure())
-				.hasSize(1);
-		assertThat(instances).filteredOn(s -> s.getHost().equals("ip2") && !s.isSecure())
-				.hasSize(1);
-		assertThat(instances)
-				.filteredOn(s -> s.getServiceId().contains("endpoint")
-						&& ((KubernetesServiceInstance) s).getNamespace().equals("test"))
-				.hasSize(1);
-		assertThat(instances)
-				.filteredOn(s -> s.getServiceId().contains("endpoint")
-						&& ((KubernetesServiceInstance) s).getNamespace().equals("test2"))
-				.hasSize(1);
-		assertThat(instances).filteredOn(s -> s.getInstanceId().equals("uid1"))
-				.hasSize(1);
-		assertThat(instances).filteredOn(s -> s.getInstanceId().equals("uid2"))
-				.hasSize(1);
-	}
-
-	@Test
-	public void getInstancesShouldBeAbleToHandleEndpointsSingleAddress() {
-		mockServer.expect().get().withPath("/api/v1/namespaces/test/endpoints/endpoint")
-				.andReturn(200, new EndpointsBuilder().withNewMetadata()
-						.withName("endpoint").endMetadata().addNewSubset().addNewAddress()
-						.withIp("ip1").withNewTargetRef().withUid("uid1").endTargetRef()
-						.endAddress().addNewPort("http", 80, "TCP").endSubset().build())
-				.once();
-
-		mockServer.expect().get().withPath("/api/v1/services/endpoint")
-				.andReturn(200, new ServiceBuilder().withNewMetadata()
-						.withName("endpoint").withLabels(new HashMap<String, String>() {
-							{
-								put("l", "v");
-							}
-						}).endMetadata().build())
-				.always();
-
-		final KubernetesDiscoveryProperties properties = new KubernetesDiscoveryProperties();
 		properties.setServiceLabels(labels);
 		properties.getMetadata().setAddLabels(false);
 		properties.getMetadata().setAddAnnotations(false);
@@ -422,6 +376,14 @@ public class KubernetesDiscoveryClientTest {
 		assertThat(instances).filteredOn(s -> s.getHost().equals("ip1") && !s.isSecure())
 				.hasSize(1);
 		assertThat(instances).filteredOn(s -> s.getHost().equals("ip2") && !s.isSecure())
+				.hasSize(1);
+		assertThat(instances)
+				.filteredOn(s -> s.getServiceId().contains("endpoint")
+						&& ((KubernetesServiceInstance) s).getNamespace().equals("test"))
+				.hasSize(1);
+		assertThat(instances)
+				.filteredOn(s -> s.getServiceId().contains("endpoint")
+						&& ((KubernetesServiceInstance) s).getNamespace().equals("test2"))
 				.hasSize(1);
 		assertThat(instances).filteredOn(s -> s.getInstanceId().equals("60")).hasSize(1);
 		assertThat(instances).filteredOn(s -> s.getInstanceId().equals("70")).hasSize(1);


### PR DESCRIPTION
As mentioned in issue #473 the namespace should be reflected in the serviceId when using discovery with all-namespaces set to true.