### PR TITLE
Account For ConfigMapPropertySources Wrapped In BootstrapPropertySources

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigurationChangeDetector.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigurationChangeDetector.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -98,9 +99,8 @@ public abstract class ConfigurationChangeDetector {
 			List<? extends MapPropertySource> l2) {
 
 		if (l1.size() != l2.size()) {
-			this.log.debug(
-					"The current number of Confimap PropertySources does not match "
-							+ "the ones loaded from the Kubernetes - No reload will take place");
+			this.log.warn("The current number of Confimap PropertySources does not match "
+					+ "the ones loaded from the Kubernetes - No reload will take place");
 			return false;
 		}
 
@@ -149,6 +149,13 @@ public abstract class ConfigurationChangeDetector {
 			}
 			else if (sourceClass.isInstance(source)) {
 				managedSources.add(sourceClass.cast(source));
+			}
+			else if (BootstrapPropertySource.class.isInstance(source)) {
+				PropertySource propertySource = ((BootstrapPropertySource) source)
+						.getDelegate();
+				if (sourceClass.isInstance(propertySource)) {
+					sources.add(propertySource);
+				}
 			}
 		}
 

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetectorTests.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetectorTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.config.reload;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.DoneableConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.junit.Test;
+
+import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
+import org.springframework.cloud.kubernetes.config.ConfigMapPropertySource;
+import org.springframework.cloud.kubernetes.config.ConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.config.SecretsPropertySourceLocator;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Ryan Baxter
+ */
+public class EventBasedConfigurationChangeDetectorTests {
+
+	@Test
+	public void verifyConfigChangesAccountsForBootstrapPropertySources() {
+		ConfigReloadProperties configReloadProperties = new ConfigReloadProperties();
+		MockEnvironment env = new MockEnvironment();
+		KubernetesClient k8sClient = mock(KubernetesClient.class);
+		ConfigMap configMap = new ConfigMap();
+		Map<String, String> data = new HashMap();
+		data.put("foo", "bar");
+		configMap.setData(data);
+		MixedOperation<ConfigMap, ConfigMapList, DoneableConfigMap, Resource<ConfigMap, DoneableConfigMap>> mixedOperation = mock(
+				MixedOperation.class);
+		Resource<ConfigMap, DoneableConfigMap> resource = mock(Resource.class);
+		when(resource.get()).thenReturn(configMap);
+		when(mixedOperation.withName(eq("myconfigmap"))).thenReturn(resource);
+		when(k8sClient.configMaps()).thenReturn(mixedOperation);
+
+		ConfigMapPropertySource configMapPropertySource = new ConfigMapPropertySource(
+				k8sClient, "myconfigmap");
+		env.getPropertySources()
+				.addFirst(new BootstrapPropertySource(configMapPropertySource));
+
+		ConfigurationUpdateStrategy configurationUpdateStrategy = mock(
+				ConfigurationUpdateStrategy.class);
+		ConfigMapPropertySourceLocator configMapLocator = mock(
+				ConfigMapPropertySourceLocator.class);
+		SecretsPropertySourceLocator secretsLocator = mock(
+				SecretsPropertySourceLocator.class);
+		EventBasedConfigurationChangeDetector detector = new EventBasedConfigurationChangeDetector(
+				env, configReloadProperties, k8sClient, configurationUpdateStrategy,
+				configMapLocator, secretsLocator);
+		List<ConfigMapPropertySource> sources = detector
+				.findPropertySources(ConfigMapPropertySource.class);
+		assertThat(sources.size()).isEqualTo(1);
+		assertThat(sources.get(0).getProperty("foo")).isEqualTo("bar");
+	}
+
+}

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstanceTests.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesServiceInstanceTests.java
@@ -37,7 +37,7 @@ public class KubernetesServiceInstanceTests {
 		EndpointPort port = new EndpointPort();
 		port.setPort(8080);
 		KubernetesServiceInstance instance = new KubernetesServiceInstance("123",
-			"myservice", address, port, Collections.emptyMap(), secure);
+				"myservice", address, port, Collections.emptyMap(), secure);
 
 		assertThat(instance.getInstanceId()).isEqualTo("123");
 		assertThat(instance.getServiceId()).isEqualTo("myservice");


### PR DESCRIPTION
The changes to how we add PropertySources in the bootstrap phase made in Spring Cloud Commons, broke the logic in config map reload https://github.com/spring-cloud/spring-cloud-commons/pull/652

These changes now account for that.

Fixes #524