### PR TITLE
upgrade fabric8 plugin version from 3.5.37 to 4.4.0 fixes gh-532

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
 		<maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
-		<fabric8.maven.plugin.version>3.5.37</fabric8.maven.plugin.version>
+		<fabric8.maven.plugin.version>4.4.0</fabric8.maven.plugin.version>
 		<groovy.version>2.4.12</groovy.version>
 		<restassured.version>3.0.2</restassured.version>
 		<spock-spring.version>1.1-groovy-2.4</spock-spring.version>


### PR DESCRIPTION
Related to issue #532 when building a sample project with `mvn clean package fabric8:deploy -Pkubernetes` but showing a different error of bad resource versions in the generated manifest files.