### PR TITLE
Fix scheduled discovery when allNamespaces property is true

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatch.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatch.java
@@ -45,12 +45,16 @@ public class KubernetesCatalogWatch implements ApplicationEventPublisherAware {
 
 	private final KubernetesClient kubernetesClient;
 
+	private final KubernetesDiscoveryProperties properties;
+
 	private final AtomicReference<List<String>> catalogEndpointsState = new AtomicReference<>();
 
 	private ApplicationEventPublisher publisher;
 
-	public KubernetesCatalogWatch(KubernetesClient kubernetesClient) {
+	public KubernetesCatalogWatch(KubernetesClient kubernetesClient,
+			KubernetesDiscoveryProperties properties) {
 		this.kubernetesClient = kubernetesClient;
+		this.properties = properties;
 	}
 
 	@Override
@@ -66,8 +70,11 @@ public class KubernetesCatalogWatch implements ApplicationEventPublisherAware {
 
 			// not all pods participate in the service discovery. only those that have
 			// endpoints.
-			List<Endpoints> endpoints = this.kubernetesClient.endpoints().list()
-					.getItems();
+			List<Endpoints> endpoints = this.properties
+					.isAllNamespaces()
+							? this.kubernetesClient.endpoints().inAnyNamespace().list()
+									.getItems()
+							: this.kubernetesClient.endpoints().list().getItems();
 			List<String> endpointsPodNames = endpoints.stream().map(Endpoints::getSubsets)
 					.filter(Objects::nonNull).flatMap(Collection::stream)
 					.map(EndpointSubset::getAddresses).filter(Objects::nonNull)

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchAutoConfiguration.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchAutoConfiguration.java
@@ -42,8 +42,9 @@ public class KubernetesCatalogWatchAutoConfiguration {
 	@ConditionalOnProperty(
 			name = "spring.cloud.kubernetes.discovery.catalog-services-watch.enabled",
 			matchIfMissing = true)
-	public KubernetesCatalogWatch kubernetesCatalogWatch(KubernetesClient client) {
-		return new KubernetesCatalogWatch(client);
+	public KubernetesCatalogWatch kubernetesCatalogWatch(KubernetesClient client,
+			KubernetesDiscoveryProperties properties) {
+		return new KubernetesCatalogWatch(client, properties);
 	}
 
 }

--- a/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchTest.java
+++ b/spring-cloud-kubernetes-discovery/src/test/java/org/springframework/cloud/kubernetes/discovery/KubernetesCatalogWatchTest.java
@@ -58,6 +58,9 @@ public class KubernetesCatalogWatchTest {
 	private KubernetesClient kubernetesClient;
 
 	@Mock
+	private KubernetesDiscoveryProperties kubernetesDiscoveryProperties;
+
+	@Mock
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	@Mock


### PR DESCRIPTION
Relates to #428 #448 #465 

**Type of request**

Bug fix

**Behavior**

When 

- the property `spring.cloud.kubernetes.discovery.all-namespaces` is true 
- and `@EnableScheduling` has been set

the service/pod discovery never see any addition/deletion of pods for a given service in a different namespace that the one the spring boot admin server is in.

**How to reproduce**

1. In a namespace `A`, deploy a spring boot application (deployment and service) with one replica
2. In a namespace `B`, deploy a spring boot admin server with the following annotations (as per the documentation of this project) :
`@SpringBootApplication
@EnableAdminServer
@EnableDiscoveryClient
@EnableScheduling`, the property `spring.cloud.kubernetes.discovery.all-namespaces` set to true (and the required rbac configuration) 
3. You should see your spring boot application properly reported in spring boot admin server, with 1 instance
4. Scale up your spring boot application (let's say 2 replicas)
5. Even after 30 secondes (the default scheduled interval), spring boot admin server still shows 1 spring boot application with 1 instance

**Expected behavior**

When these conditions are met we expect to see the dynamically updated list of instances in spring boot admin server without restarting it.

Please let me know if there is anything wrong with this patch, I had never used this lib before this morning so I might be missing something obvious. Adding `inAnyNamespace()` definitely fixes the issue though

Thanks