### PR TITLE
Close the connection of ad hoc kubernetes client

### DIFF
--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileEnvironmentPostProcessor.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/profile/KubernetesProfileEnvironmentPostProcessor.java
@@ -49,9 +49,7 @@ public class KubernetesProfileEnvironmentPostProcessor
 			return;
 		}
 
-		final StandardPodUtils podUtils = new StandardPodUtils(
-				new DefaultKubernetesClient());
-		if (podUtils.isInsideKubernetes()) {
+		if (isInsideKubernetes()) {
 			if (hasKubernetesProfile(environment)) {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("'kubernetes' already in list of active profiles");
@@ -69,6 +67,13 @@ public class KubernetesProfileEnvironmentPostProcessor
 				LOG.warn(
 						"Not running inside kubernetes. Skipping 'kubernetes' profile activation.");
 			}
+		}
+	}
+
+	private boolean isInsideKubernetes() {
+		try (DefaultKubernetesClient client = new DefaultKubernetesClient()) {
+			final StandardPodUtils podUtils = new StandardPodUtils(client);
+			return podUtils.isInsideKubernetes();
 		}
 	}
 


### PR DESCRIPTION
This patch closes the connection pool of the ad-hoc kubernetes client for profile detection. This connection pool is unused after running the `KubernetsProfileEnvironmentPostProcessor`. And also, this PostProcessor may be called multiple times. This patch will prevent unnecessary connection pools from increasing.