### PR TITLE
Fix value data-type & entry-set order issues of properties bound to Map

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.kubernetes.config;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -35,12 +35,14 @@ import org.springframework.util.StringUtils;
 import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.KEY_VALUE_TO_PROPERTIES;
 import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.PROPERTIES_TO_MAP;
 import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.yamlParserGenerator;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.throwingMerger;
 
 /**
  * A {@link MapPropertySource} that uses Kubernetes config maps.
  *
  * @author Ioannis Canellos
  * @author Ali Shahbour
+ * @author Michael Moudatsos
  */
 public class ConfigMapPropertySource extends MapPropertySource {
 
@@ -86,10 +88,10 @@ public class ConfigMapPropertySource extends MapPropertySource {
 				.toString();
 	}
 
-	private static Map<String, String> getData(KubernetesClient client, String name,
+	private static Map<String, Object> getData(KubernetesClient client, String name,
 			String namespace, Environment environment) {
 		try {
-			Map<String, String> result = new HashMap<>();
+			Map<String, Object> result = new LinkedHashMap<>();
 			ConfigMap map = StringUtils.isEmpty(namespace)
 					? client.configMaps().withName(name).get()
 					: client.configMaps().inNamespace(namespace).withName(name).get();
@@ -124,10 +126,10 @@ public class ConfigMapPropertySource extends MapPropertySource {
 					+ namespace + "]. Ignoring.", e);
 		}
 
-		return new HashMap<>();
+		return new LinkedHashMap<>();
 	}
 
-	private static Map<String, String> processAllEntries(Map<String, String> input,
+	private static Map<String, Object> processAllEntries(Map<String, String> input,
 			Environment environment) {
 
 		Set<Entry<String, String>> entrySet = input.entrySet();
@@ -163,16 +165,17 @@ public class ConfigMapPropertySource extends MapPropertySource {
 		return defaultProcessAllEntries(input, environment);
 	}
 
-	private static Map<String, String> defaultProcessAllEntries(Map<String, String> input,
+	private static Map<String, Object> defaultProcessAllEntries(Map<String, String> input,
 			Environment environment) {
 
 		return input.entrySet().stream()
 				.map(e -> extractProperties(e.getKey(), e.getValue(), environment))
 				.filter(m -> !m.isEmpty()).flatMap(m -> m.entrySet().stream())
-				.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+				.collect(Collectors.toMap(Entry::getKey, Entry::getValue,
+						throwingMerger(), LinkedHashMap::new));
 	}
 
-	private static Map<String, String> extractProperties(String resourceName,
+	private static Map<String, Object> extractProperties(String resourceName,
 			String content, Environment environment) {
 
 		if (resourceName.equals(APPLICATION_YAML)
@@ -184,16 +187,16 @@ public class ConfigMapPropertySource extends MapPropertySource {
 			return KEY_VALUE_TO_PROPERTIES.andThen(PROPERTIES_TO_MAP).apply(content);
 		}
 
-		return new HashMap<String, String>() {
+		return new LinkedHashMap<String, Object>() {
 			{
 				put(resourceName, content);
 			}
 		};
 	}
 
-	private static Map<String, Object> asObjectMap(Map<String, String> source) {
-		return source.entrySet().stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	private static Map<String, Object> asObjectMap(Map<String, Object> source) {
+		return source.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+				Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
 	}
 
 }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -34,8 +34,8 @@ import org.springframework.util.StringUtils;
 
 import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.KEY_VALUE_TO_PROPERTIES;
 import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.PROPERTIES_TO_MAP;
-import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.yamlParserGenerator;
 import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.throwingMerger;
+import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.yamlParserGenerator;
 
 /**
  * A {@link MapPropertySource} that uses Kubernetes config maps.

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -47,6 +47,7 @@ import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.ya
  * A {@link PropertySourceLocator} that uses config maps.
  *
  * @author Ioannis Canellos
+ * @author Michael Moudatsos
  */
 @Order(0)
 public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
@@ -133,7 +134,7 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 	}
 
 	private void addPropertySourceIfNeeded(
-			Function<String, Map<String, String>> contentToMapFunction, String content,
+			Function<String, Map<String, Object>> contentToMapFunction, String content,
 			String name, CompositePropertySource composite) {
 
 		Map<String, Object> map = new HashMap<>();

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,7 @@ import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus
  * Utility class to work with property sources.
  *
  * @author Georgios Andrianakis
+ * @author Michael Moudatsos
  */
 public final class PropertySourceUtils {
 
@@ -50,9 +52,9 @@ public final class PropertySourceUtils {
 			throw new IllegalArgumentException();
 		}
 	};
-	static final Function<Properties, Map<String, String>> PROPERTIES_TO_MAP = p -> p
+	static final Function<Properties, Map<String, Object>> PROPERTIES_TO_MAP = p -> p
 			.entrySet().stream().collect(Collectors.toMap(e -> String.valueOf(e.getKey()),
-					e -> String.valueOf(e.getValue())));
+					Map.Entry::getValue, throwingMerger(), java.util.LinkedHashMap::new));
 
 	private PropertySourceUtils() {
 		throw new IllegalStateException("Can't instantiate a utility class");
@@ -73,6 +75,12 @@ public final class PropertySourceUtils {
 			});
 			yamlFactory.setResources(new ByteArrayResource(s.getBytes()));
 			return yamlFactory.getObject();
+		};
+	}
+
+	static <T> BinaryOperator<T> throwingMerger() {
+		return (u, v) -> {
+			throw new IllegalStateException(String.format("Duplicate key %s", u));
 		};
 	}
 

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
@@ -86,8 +86,8 @@ public class ConfigMapsTest {
 				this.server.getClient().inNamespace(namespace), configMapName);
 
 		assertThat(cmps.getProperty("dummy.property.string1")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo("1");
-		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo("true");
+		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo(1);
+		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo(true);
 	}
 
 	@Test
@@ -109,8 +109,8 @@ public class ConfigMapsTest {
 				this.server.getClient().inNamespace(namespace), configMapName);
 
 		assertThat(cmps.getProperty("dummy.property.string2")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int2")).isEqualTo("1");
-		assertThat(cmps.getProperty("dummy.property.bool2")).isEqualTo("true");
+		assertThat(cmps.getProperty("dummy.property.int2")).isEqualTo(1);
+		assertThat(cmps.getProperty("dummy.property.bool2")).isEqualTo(true);
 	}
 
 	@Test

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
@@ -86,8 +86,8 @@ public class ConfigMapsTest {
 				this.server.getClient().inNamespace(namespace), configMapName);
 
 		assertThat(cmps.getProperty("dummy.property.string1")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo(1);
-		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo(true);
+		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo("1");
+		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo("true");
 	}
 
 	@Test
@@ -193,8 +193,8 @@ public class ConfigMapsTest {
 
 		// application.properties should be read correctly
 		assertThat(cmps.getProperty("dummy.property.string1")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo(1);
-		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo(true);
+		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo("1");
+		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo("true");
 
 		// the adhoc.properties file should not be parsed
 		assertThat(cmps.getProperty("dummy.property.bool2")).isNull();

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
@@ -129,8 +129,8 @@ public class ConfigMapsTest {
 				this.server.getClient().inNamespace(namespace), configMapName);
 
 		assertThat(cmps.getProperty("dummy.property.string3")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int3")).isEqualTo("1");
-		assertThat(cmps.getProperty("dummy.property.bool3")).isEqualTo("true");
+		assertThat(cmps.getProperty("dummy.property.int3")).isEqualTo(1);
+		assertThat(cmps.getProperty("dummy.property.bool3")).isEqualTo(true);
 	}
 
 	@Test
@@ -193,8 +193,8 @@ public class ConfigMapsTest {
 
 		// application.properties should be read correctly
 		assertThat(cmps.getProperty("dummy.property.string1")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo("1");
-		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo("true");
+		assertThat(cmps.getProperty("dummy.property.int1")).isEqualTo(1);
+		assertThat(cmps.getProperty("dummy.property.bool1")).isEqualTo(true);
 
 		// the adhoc.properties file should not be parsed
 		assertThat(cmps.getProperty("dummy.property.bool2")).isNull();


### PR DESCRIPTION
Issue: properties bound to a java.util.Map object do not maintain their
definition order and their values lose their data-type, since they 're
converted to String values.
This fix mainly targets org.springframework.cloud.kubernetes.config
.PropertySourceUtils.PROPERTIES_TO_MAP implementation: Configuration
properties that are bound to a java.util.Map had their value's type
affected by the use of .toString() on each entry's value during Map
entry processing. Moreover, the use of java.util.stream
.Collectors.toMap(java.util.function.Function<? super T,? extends K>,
java.util.function.Function<? super T,? extends U>) when processing
Map-bound properties, resulted in losing the entry insertion order of
the original Map. The fix entails usage of the original entry value and
a Collectors.toMap() variant that maintains the behavior of the method
previously used, yet uses a java.util.LinkedHashMap as the target data
structure for the processed entries. Ramification changes on method
signature and return type have been applied where needed.