### PR TITLE
Fix value data-type & entry-set order of yml properties bound to Map

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -47,6 +47,7 @@ import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.ya
  * A {@link PropertySourceLocator} that uses config maps.
  *
  * @author Ioannis Canellos
+ * @author Michael Moudatsos
  */
 @Order(0)
 public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
@@ -133,7 +134,7 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 	}
 
 	private void addPropertySourceIfNeeded(
-			Function<String, Map<String, String>> contentToMapFunction, String content,
+			Function<String, Map<String, Object>> contentToMapFunction, String content,
 			String name, CompositePropertySource composite) {
 
 		Map<String, Object> map = new HashMap<>();

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/PropertySourceUtils.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,7 @@ import static org.springframework.beans.factory.config.YamlProcessor.MatchStatus
  * Utility class to work with property sources.
  *
  * @author Georgios Andrianakis
+ * @author Michael Moudatsos
  */
 public final class PropertySourceUtils {
 
@@ -50,9 +52,9 @@ public final class PropertySourceUtils {
 			throw new IllegalArgumentException();
 		}
 	};
-	static final Function<Properties, Map<String, String>> PROPERTIES_TO_MAP = p -> p
+	static final Function<Properties, Map<String, Object>> PROPERTIES_TO_MAP = p -> p
 			.entrySet().stream().collect(Collectors.toMap(e -> String.valueOf(e.getKey()),
-					e -> String.valueOf(e.getValue())));
+					Map.Entry::getValue, throwingMerger(), java.util.LinkedHashMap::new));
 
 	private PropertySourceUtils() {
 		throw new IllegalStateException("Can't instantiate a utility class");
@@ -73,6 +75,12 @@ public final class PropertySourceUtils {
 			});
 			yamlFactory.setResources(new ByteArrayResource(s.getBytes()));
 			return yamlFactory.getObject();
+		};
+	}
+
+	static <T> BinaryOperator<T> throwingMerger() {
+		return (u, v) -> {
+			throw new IllegalStateException(String.format("Duplicate key %s", u));
 		};
 	}
 

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/ConfigMapsTest.java
@@ -109,8 +109,8 @@ public class ConfigMapsTest {
 				this.server.getClient().inNamespace(namespace), configMapName);
 
 		assertThat(cmps.getProperty("dummy.property.string2")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int2")).isEqualTo("1");
-		assertThat(cmps.getProperty("dummy.property.bool2")).isEqualTo("true");
+		assertThat(cmps.getProperty("dummy.property.int2")).isEqualTo(1);
+		assertThat(cmps.getProperty("dummy.property.bool2")).isEqualTo(true);
 	}
 
 	@Test
@@ -129,8 +129,8 @@ public class ConfigMapsTest {
 				this.server.getClient().inNamespace(namespace), configMapName);
 
 		assertThat(cmps.getProperty("dummy.property.string3")).isEqualTo("a");
-		assertThat(cmps.getProperty("dummy.property.int3")).isEqualTo("1");
-		assertThat(cmps.getProperty("dummy.property.bool3")).isEqualTo("true");
+		assertThat(cmps.getProperty("dummy.property.int3")).isEqualTo(1);
+		assertThat(cmps.getProperty("dummy.property.bool3")).isEqualTo(true);
 	}
 
 	@Test


### PR DESCRIPTION
implementing PR #554 on 1.1.x branch

Issue: properties bound to a java.util.Map object do not maintain their
definition order and their values lose their data-type, since they 're
converted to String values.
This fix mainly targets org.springframework.cloud.kubernetes.config
.PropertySourceUtils.PROPERTIES_TO_MAP implementation: Configuration
properties that are bound to a java.util.Map had their value's type
affected by the use of .toString() on each entry's value during Map
entry processing. Moreover, the use of java.util.stream
.Collectors.toMap(java.util.function.Function<? super T,? extends K>,
java.util.function.Function<? super T,? extends U>) when processing
Map-bound properties, resulted in losing the entry insertion order of
the original Map. The fix entails usage of the original entry value and
a Collectors.toMap() variant that maintains the behavior of the method
previously used, yet uses a java.util.LinkedHashMap as the target data
structure for the processed entries. Ramification changes on method
signature and return type have been applied where needed.