### PR TITLE
Fix for KubernetesAutoConfiguration erroneously overwriting user password with proxy password

### DIFF
--- a/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesAutoConfiguration.java
+++ b/spring-cloud-kubernetes-core/src/main/java/org/springframework/cloud/kubernetes/KubernetesAutoConfiguration.java
@@ -130,7 +130,7 @@ public class KubernetesAutoConfiguration {
 						base.getHttpsProxy()))
 				.withProxyUsername(or(kubernetesClientProperties.getProxyUsername(),
 						base.getProxyUsername()))
-				.withPassword(or(kubernetesClientProperties.getProxyPassword(),
+				.withProxyPassword(or(kubernetesClientProperties.getProxyPassword(),
 						base.getProxyPassword()))
 				.withNoProxy(
 						or(kubernetesClientProperties.getNoProxy(), base.getNoProxy()))


### PR DESCRIPTION
Issue: `KubernetesAutoConfiguration.kubernetesClientConfig` calls `withPassword` twice - the second time with proxy password resulting in user password replaced with proxy password.

Fix: the second `withPassword` method call is replaced with `withProxyPassword`.