### PR TITLE
Re-watch events when disconnected from k8s API

### DIFF
--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetectorTests.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetectorTests.java
@@ -16,21 +16,35 @@
 
 package org.springframework.cloud.kubernetes.config.reload;
 
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.DoneableConfigMap;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.StatusBuilder;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.WatchEventBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.springframework.cloud.bootstrap.config.BootstrapPropertySource;
+import org.springframework.cloud.kubernetes.config.ConfigMapConfigProperties;
 import org.springframework.cloud.kubernetes.config.ConfigMapPropertySource;
 import org.springframework.cloud.kubernetes.config.ConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.config.SecretsConfigProperties;
 import org.springframework.cloud.kubernetes.config.SecretsPropertySourceLocator;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -43,6 +57,105 @@ import static org.mockito.Mockito.when;
  * @author Ryan Baxter
  */
 public class EventBasedConfigurationChangeDetectorTests {
+
+	@ClassRule
+	public static KubernetesServer mockServer = new KubernetesServer(false);
+
+	private static KubernetesClient mockClient;
+
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		mockClient = mockServer.getClient().inNamespace("test");
+	}
+
+	@Test
+	public void reWatchConfigMapsOnFailure() throws InterruptedException {
+		ConfigMap sample = new ConfigMapBuilder().withNewMetadata().withName("sample")
+				.endMetadata().addToData("key", "value").build();
+		ConfigMap modifiedSample = new ConfigMapBuilder().withNewMetadata()
+				.withName("sample").endMetadata().addToData("key", "newValue").build();
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/configmaps/sample")
+				.andReturn(HttpURLConnection.HTTP_OK, sample).once();
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/configmaps/sample")
+				.andReturn(HttpURLConnection.HTTP_OK, modifiedSample).always();
+
+		WatchEvent outdatedEvent = new WatchEventBuilder().withStatusObject(
+				new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+						.withMessage("too old resource version: 35168187 (41169815)")
+						.build())
+				.build();
+		WatchEvent addedEvent = new WatchEvent(modifiedSample, "MODIFIED");
+		mockServer.expect().get()
+				.withPath("/api/v1/namespaces/test/configmaps?watch=true")
+				.andUpgradeToWebSocket().open().waitFor(10L).andEmit(outdatedEvent).done()
+				.once();
+		mockServer.expect().get()
+				.withPath("/api/v1/namespaces/test/configmaps?watch=true")
+				.andUpgradeToWebSocket().open().waitFor(10L).andEmit(addedEvent).done()
+				.always();
+
+		final CountDownLatch reloadLatch = new CountDownLatch(1);
+		ConfigurationUpdateStrategy strategy = new ConfigurationUpdateStrategy("test",
+				reloadLatch::countDown);
+		ConfigMapConfigProperties configProps = new ConfigMapConfigProperties();
+		configProps.setName("sample");
+		configProps.setNamespace("test");
+		ConfigMapPropertySourceLocator locator = new ConfigMapPropertySourceLocator(
+				mockClient, configProps);
+		MockEnvironment env = new MockEnvironment();
+		env.getPropertySources().addFirst(locator.locate(env));
+		ConfigReloadProperties reloadProps = new ConfigReloadProperties();
+		EventBasedConfigurationChangeDetector detector = new EventBasedConfigurationChangeDetector(
+				env, reloadProps, mockClient, strategy, locator, null);
+
+		detector.watch();
+		assertThat(reloadLatch.await(10L, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	public void reWatchSecretsOnFailure() throws InterruptedException {
+		Secret sample = new SecretBuilder().withNewMetadata().withName("sample")
+				.endMetadata().addToData("key", "value").build();
+		Secret modifiedSample = new SecretBuilder().withNewMetadata().withName("sample")
+				.endMetadata().addToData("key", "newValue").build();
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/secrets/sample")
+				.andReturn(HttpURLConnection.HTTP_OK, sample).once();
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/secrets/sample")
+				.andReturn(HttpURLConnection.HTTP_OK, modifiedSample).always();
+
+		WatchEvent outdatedEvent = new WatchEventBuilder().withStatusObject(
+				new StatusBuilder().withCode(HttpURLConnection.HTTP_GONE)
+						.withMessage("too old resource version: 35168187 (41169815)")
+						.build())
+				.build();
+		WatchEvent addedEvent = new WatchEvent(modifiedSample, "MODIFIED");
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/secrets?watch=true")
+				.andUpgradeToWebSocket().open().waitFor(10L).andEmit(outdatedEvent).done()
+				.once();
+		mockServer.expect().get().withPath("/api/v1/namespaces/test/secrets?watch=true")
+				.andUpgradeToWebSocket().open().waitFor(10L).andEmit(addedEvent).done()
+				.always();
+
+		final CountDownLatch reloadLatch = new CountDownLatch(1);
+		ConfigurationUpdateStrategy strategy = new ConfigurationUpdateStrategy("test",
+				reloadLatch::countDown);
+		SecretsConfigProperties secretsProps = new SecretsConfigProperties();
+		secretsProps.setEnableApi(true);
+		secretsProps.setName("sample");
+		secretsProps.setNamespace("test");
+		SecretsPropertySourceLocator locator = new SecretsPropertySourceLocator(
+				mockClient, secretsProps);
+		MockEnvironment env = new MockEnvironment();
+		env.getPropertySources().addFirst(locator.locate(env));
+		ConfigReloadProperties reloadProps = new ConfigReloadProperties();
+		reloadProps.setMonitoringConfigMaps(false);
+		reloadProps.setMonitoringSecrets(true);
+		EventBasedConfigurationChangeDetector detector = new EventBasedConfigurationChangeDetector(
+				env, reloadProps, mockClient, strategy, null, locator);
+
+		detector.watch();
+		assertThat(reloadLatch.await(10L, TimeUnit.SECONDS)).isTrue();
+	}
 
 	@Test
 	public void verifyConfigChangesAccountsForBootstrapPropertySources() {


### PR DESCRIPTION
If any errors occur and kubernetes client is disconnected from the API, `EventBasedConfigurationChangeDetector` should re-watch the events for external resources like ConfigMap. This patch implements the `onClose` methods of Watcher for the error handling:

```java
/**
 * Run when the watcher finally closes.
 *
 * @param cause What caused the watcher to be closed. Null means normal close.
 */
void onClose(KubernetesClientException cause);
```
ref: https://github.com/fabric8io/kubernetes-client/blob/v4.4.0/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Watcher.java#L27


### An example of the errors

In my case, the following exception is passed to `onClose` method under the same situation as reported in https://github.com/spring-cloud/spring-cloud-kubernetes/issues/558:

```
io.fabric8.kubernetes.client.KubernetesClientException: too old resource version: 35168187 (41169815)
	at io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager$1.onMessage(WatchConnectionManager.java:259) ~[kubernetes-client-4.9.0.jar!/:na]
	at okhttp3.internal.ws.RealWebSocket.onReadMessage(RealWebSocket.java:323) ~[okhttp-3.12.0.jar!/:na]
	at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:219) ~[okhttp-3.12.0.jar!/:na]
	at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:105) ~[okhttp-3.12.0.jar!/:na]
	at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.java:274) ~[okhttp-3.12.0.jar!/:na]
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:214) ~[okhttp-3.12.0.jar!/:na]
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:206) ~[okhttp-3.12.0.jar!/:na]
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32) ~[okhttp-3.12.0.jar!/:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:n
```

The kubernetes client will not automatically reconnect when such an error occurs. The following code is causing the reconnection to be interrupted:

https://github.com/fabric8io/kubernetes-client/blob/v4.4.0/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/WatchConnectionManager.java#L285-L292

### Releated Issues

* https://github.com/spring-cloud/spring-cloud-kubernetes/issues/558
* https://github.com/spring-cloud/spring-cloud-kubernetes/issues/557