### PR TITLE
Support endpoints without ports specified in discovery client.

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -216,8 +216,10 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 			else {
 				portPredicate = port -> true;
 			}
+			// if no port is found, return an empty object
+			// endpoints without ports are valid in Kubernetes
 			endpointPort = ports.stream().filter(portPredicate).findAny()
-					.orElseThrow(IllegalStateException::new);
+						.orElse(new EndpointPort());
 		}
 		return endpointPort;
 	}


### PR DESCRIPTION
Support endpoints without ports specified in discovery client.

Kubernetes considers endpoints without ports to be valid.

resolves https://github.com/spring-cloud/spring-cloud-kubernetes/issues/513