### PR TITLE
Replace fabric8-maven-plugin with Eclipse JKube Kubernetes Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<jkube.version>1.0.0-rc-1</jkube.version>
+		<jkube.version>1.0.0</jkube.version>
 		<groovy.version>2.4.12</groovy.version>
 		<restassured.version>3.0.2</restassured.version>
 		<spock-spring.version>1.1-groovy-2.4</spock-spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<fabric8.maven.plugin.version>4.4.0</fabric8.maven.plugin.version>
+		<jkube.version>1.0.0-rc-1</jkube.version>
 		<groovy.version>2.4.12</groovy.version>
 		<restassured.version>3.0.2</restassured.version>
 		<spock-spring.version>1.1-groovy-2.4</spock-spring.version>

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
@@ -19,27 +19,24 @@ This will make sure that the docker images that you build are available to the m
 # Hello World Example
 
 This Spring Boot application exposes an endpoint that we can call to receive a `Hello World` message as response. The application is configured using the 
-@RestController and the method returning the message is annotated with `@RequestMapping("/")` 
+@RestController and the method returning the message is annotated with `@GetMapping("/")` 
 
-The uberjar of the Spring Boot application is packaged within a Docker image using the [Fabric8 Maven plugin](maven.fabric8.io) and next deployed top of the Kubernetes management platform as a pod 
-using the replication controller created by the plugin.
+The uberjar of the Spring Boot application is packaged within a Docker image using [Eclipse JKube's Kubernetes Maven plugin](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin) and next deployed top of the Kubernetes management platform as a pod 
+using the Deployment created by the plugin.
 
 
 Once you have the environment set up (minikube or kubectl configured against a kubernetes cluster)
 
 You can play with this Spring Boot application in the cloud using the following maven command to deploy it:
 ```
-mvn clean package fabric8:deploy -Pkubernetes
+mvn clean package k8s:deploy -Pkubernetes
 ```  
-   
-**Note**: Unfortuntaly, when you deploy using the fabric8 plugin, the readyness and liveness probes fail to point to the right actuator URL due a lack of support for spring boot. 
-This push you to edit the generated deployment inside kubernetes and change these probes which points to "path": "/health" to  "path": "/actuator/health". 
-This will make your deployment go green. This issue is already reported into the fabric8 community: https://github.com/fabric8io/fabric8-maven-plugin/issues/1178   
-   
+
 When the application has been deployed, you can access its service or endpoint url using this command:
 ```   
-minikube service kubernetes-hello-world --url
+minikube service hello-world-example --url
 ```
+Service name is picked up from `application.properties` `spring.application.name` property.
   
 And next you can curl the endpoint using the url returned by the previous command
 

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/README.md
@@ -21,8 +21,9 @@ This will make sure that the docker images that you build are available to the m
 This Spring Boot application exposes an endpoint that we can call to receive a `Hello World` message as response. The application is configured using the 
 @RestController and the method returning the message is annotated with `@GetMapping("/")` 
 
-The uberjar of the Spring Boot application is packaged within a Docker image using [Eclipse JKube's Kubernetes Maven plugin](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin) and next deployed top of the Kubernetes management platform as a pod 
-using the Deployment created by the plugin.
+The uberjar of the Spring Boot application is packaged within a Docker image using Spring Boot Maven Plugin
+and next deployed on top of the Kubernetes management platform as a pod 
+using the Deployment created by [Eclipse JKube's Kubernetes Maven plugin](https://www.eclipse.org/jkube/docs/kubernetes-maven-plugin).
 
 
 Once you have the environment set up (minikube or kubectl configured against a kubernetes cluster)

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/pom.xml
@@ -16,6 +16,12 @@
 		cloud kubernetes app
 	</description>
 
+	<properties>
+		<spring-boot.build-image.skip>true</spring-boot.build-image.skip>
+		<spring-boot.build-image.imageName>spring-cloud-kubernetes/${project.artifactId}:latest</spring-boot.build-image.imageName>
+		<jkube.generator.name>${spring-boot.build-image.imageName}</jkube.generator.name>
+	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -100,6 +106,7 @@
 					<execution>
 						<goals>
 							<goal>repackage</goal>
+							<goal>build-image</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -143,33 +150,10 @@
 	<profiles>
 		<profile>
 			<id>kubernetes</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.jkube</groupId>
-						<artifactId>kubernetes-maven-plugin</artifactId>
-						<version>${jkube.version}</version>
-						<executions>
-							<execution>
-								<id>jkube</id>
-								<goals>
-									<goal>resource</goal>
-									<goal>build</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<enricher>
-								<config>
-									<jkube-service>
-										<type>NodePort</type>
-									</jkube-service>
-								</config>
-							</enricher>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
+			<properties>
+				<spring-boot.build-image.skip>false</spring-boot.build-image.skip>
+				<jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
+			</properties>
 		</profile>
 		<profile>
 			<id>release</id>
@@ -195,22 +179,11 @@
 
 		<profile>
 			<id>integration</id>
+			<properties>
+				<spring-boot.build-image.skip>false</spring-boot.build-image.skip>
+			</properties>
 			<build>
 				<plugins>
-					<plugin>
-						<groupId>org.eclipse.jkube</groupId>
-						<artifactId>kubernetes-maven-plugin</artifactId>
-						<version>${jkube.version}</version>
-						<executions>
-							<execution>
-								<id>jkube</id>
-								<goals>
-									<goal>resource</goal>
-									<goal>build</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-failsafe-plugin</artifactId>
@@ -226,6 +199,8 @@
 							</execution>
 						</executions>
 						<configuration>
+							<!-- https://stackoverflow.com/a/52532095 -->
+							<classesDirectory>${project.build.outputDirectory}</classesDirectory>
 							<skipTests>false</skipTests>
 							<skipITs>false</skipITs>
 						</configuration>

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/pom.xml
@@ -125,12 +125,12 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>io.fabric8</groupId>
-				<artifactId>fabric8-maven-plugin</artifactId>
-				<version>${fabric8.maven.plugin.version}</version>
+				<groupId>org.eclipse.jkube</groupId>
+				<artifactId>kubernetes-maven-plugin</artifactId>
+				<version>${jkube.version}</version>
 				<executions>
 					<execution>
-						<id>fmp</id>
+						<id>jkube</id>
 						<goals>
 							<goal>resource</goal>
 						</goals>
@@ -146,12 +146,12 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8.maven.plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>build</goal>
@@ -161,9 +161,9 @@
 						<configuration>
 							<enricher>
 								<config>
-									<fmp-service>
+									<jkube-service>
 										<type>NodePort</type>
-									</fmp-service>
+									</jkube-service>
 								</config>
 							</enricher>
 						</configuration>
@@ -176,12 +176,12 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8.maven.plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>helm</goal>
@@ -198,12 +198,12 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8.maven.plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>build</goal>

--- a/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/java/org/springframework/cloud/kubernetes/examples/HelloController.java
+++ b/spring-cloud-kubernetes-examples/kubernetes-hello-world-example/src/main/java/org/springframework/cloud/kubernetes/examples/HelloController.java
@@ -23,7 +23,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,12 +34,12 @@ public class HelloController {
 	@Autowired
 	private DiscoveryClient discoveryClient;
 
-	@RequestMapping("/")
+	@GetMapping("/")
 	public String hello() {
 		return "Hello World";
 	}
 
-	@RequestMapping("/services")
+	@GetMapping("/services")
 	public List<String> services() {
 		return this.discoveryClient.getServices();
 	}

--- a/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/README.md
@@ -2,7 +2,7 @@
 
 ## Setting up the Environment
 
-This example uses a Fabric8 Maven Plugin to deploy an application to a Kubernetes cluster.
+This example uses a Eclipse JKube's Kubernetes Maven Plugin to deploy an application to a Kubernetes cluster.
 To try it locally, download and install [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).
 
 Once Minikube is downloaded, start it with the following command:
@@ -37,7 +37,7 @@ kubectl apply -f leader-rolebinding.yml
 
 Now build and deploy the application:
 ```
-mvn clean fabric8:deploy -Pkubernetes
+mvn clean package k8s:deploy -Pkubernetes
 ```
 
 This will deploy a single application instance to the cluster and that instance will automatically become a leader.

--- a/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/pom.xml
@@ -60,9 +60,9 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>io.fabric8</groupId>
-					<artifactId>fabric8-maven-plugin</artifactId>
-					<version>${fabric8.maven.plugin.version}</version>
+					<groupId>org.eclipse.jkube</groupId>
+					<artifactId>kubernetes-maven-plugin</artifactId>
+					<version>${jkube.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -100,11 +100,11 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>build</goal>
@@ -114,9 +114,9 @@
 						<configuration>
 							<enricher>
 								<config>
-									<fmp-service>
+									<jkube-service>
 										<type>NodePort</type>
-									</fmp-service>
+									</jkube-service>
 								</config>
 							</enricher>
 						</configuration>

--- a/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/pom.xml
@@ -14,6 +14,12 @@
 	<description>Leader election demonstration with Spring Integration and ConfigMap
 	</description>
 
+	<properties>
+		<spring-boot.build-image.skip>true</spring-boot.build-image.skip>
+		<spring-boot.build-image.imageName>spring-cloud-kubernetes/${project.artifactId}:latest</spring-boot.build-image.imageName>
+		<jkube.generator.name>${spring-boot.build-image.imageName}</jkube.generator.name>
+	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -75,6 +81,13 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-image</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -97,6 +110,9 @@
 	<profiles>
 		<profile>
 			<id>kubernetes</id>
+			<properties>
+				<spring-boot.build-image.skip>false</spring-boot.build-image.skip>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -107,7 +123,6 @@
 								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
-									<goal>build</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/README.md
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/README.md
@@ -25,10 +25,10 @@ The application consists of a timed bean that periodically prints a message to t
 The message can be changed using a config map.
 
 ### Running the example
-Once you have your environment set up, you can deploy the application using the fabric8 maven plugin:
+Once you have your environment set up, you can deploy the application using the Eclipse JKube Kubernetes Maven Plugin:
 
 ```
-mvn clean install fabric8:build fabric8:deploy -Pintegration
+mvn clean install k8s:deploy -Pkubernetes
 ```
 
 ### Changing the configuration

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
@@ -104,12 +104,12 @@
 			</plugin>
 
 			<plugin>
-				<groupId>io.fabric8</groupId>
-				<artifactId>fabric8-maven-plugin</artifactId>
-				<version>${fabric8.maven.plugin.version}</version>
+				<groupId>org.eclipse.jkube</groupId>
+				<artifactId>kubernetes-maven-plugin</artifactId>
+				<version>${jkube.version}</version>
 				<executions>
 					<execution>
-						<id>fmp</id>
+						<id>jkube</id>
 						<goals>
 							<goal>resource</goal>
 						</goals>
@@ -118,12 +118,12 @@
 				<configuration>
 					<enricher>
 						<config>
-							<fmp-controller>
+							<jkube-controller>
 								<name>spring-cloud-reload</name>
-							</fmp-controller>
-							<fmp-service>
+							</jkube-controller>
+							<jkube-service>
 								<name>spring-cloud-reload</name>
-							</fmp-service>
+							</jkube-service>
 						</config>
 					</enricher>
 				</configuration>
@@ -137,12 +137,12 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8.maven.plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>build</goal>
@@ -152,13 +152,13 @@
 						<configuration>
 							<enricher>
 								<config>
-									<fmp-controller>
+									<jkube-controller>
 										<name>spring-cloud-reload</name>
-									</fmp-controller>
-									<fmp-service>
+									</jkube-controller>
+									<jkube-service>
 										<name>spring-cloud-reload</name>
 										<type>NodePort</type>
-									</fmp-service>
+									</jkube-service>
 								</config>
 							</enricher>
 						</configuration>
@@ -171,12 +171,12 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8.maven.plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>helm</goal>
@@ -193,12 +193,12 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>io.fabric8</groupId>
-						<artifactId>fabric8-maven-plugin</artifactId>
-						<version>${fabric8.maven.plugin.version}</version>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>kubernetes-maven-plugin</artifactId>
+						<version>${jkube.version}</version>
 						<executions>
 							<execution>
-								<id>fmp</id>
+								<id>jkube</id>
 								<goals>
 									<goal>resource</goal>
 									<goal>helm</goal>

--- a/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
+++ b/spring-cloud-kubernetes-examples/kubernetes-reload-example/pom.xml
@@ -46,6 +46,9 @@
 
 	<properties>
 		<hibernate-validator.version>5.3.5.Final</hibernate-validator.version>
+		<spring-boot.build-image.skip>true</spring-boot.build-image.skip>
+		<spring-boot.build-image.imageName>spring-cloud-kubernetes/${project.artifactId}:latest</spring-boot.build-image.imageName>
+		<jkube.generator.name>${spring-boot.build-image.imageName}</jkube.generator.name>
 	</properties>
 
 	<dependencies>
@@ -88,6 +91,7 @@
 					<execution>
 						<goals>
 							<goal>repackage</goal>
+							<goal>build-image</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -134,37 +138,10 @@
 	<profiles>
 		<profile>
 			<id>kubernetes</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.eclipse.jkube</groupId>
-						<artifactId>kubernetes-maven-plugin</artifactId>
-						<version>${jkube.version}</version>
-						<executions>
-							<execution>
-								<id>jkube</id>
-								<goals>
-									<goal>resource</goal>
-									<goal>build</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<enricher>
-								<config>
-									<jkube-controller>
-										<name>spring-cloud-reload</name>
-									</jkube-controller>
-									<jkube-service>
-										<name>spring-cloud-reload</name>
-										<type>NodePort</type>
-									</jkube-service>
-								</config>
-							</enricher>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
+			<properties>
+				<spring-boot.build-image.skip>false</spring-boot.build-image.skip>
+				<jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
+			</properties>
 		</profile>
 		<profile>
 			<id>release</id>
@@ -190,6 +167,9 @@
 
 		<profile>
 			<id>integration</id>
+			<properties>
+				<spring-boot.build-image.skip>false</spring-boot.build-image.skip>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -202,7 +182,6 @@
 								<goals>
 									<goal>resource</goal>
 									<goal>helm</goal>
-									<goal>build</goal>
 								</goals>
 							</execution>
 						</executions>


### PR DESCRIPTION
[Fabric8 Maven Plugin](https://github.com/fabric8io/fabric8-maven-plugin) (FMP) will be deprecated soon, [Eclipse JKube](https://github.com/eclipse/jkube) should be used instead.

Eclipse JKube 1.0.0-rc-1 was recently released, and as part of the core maintainer team, we need feedback from the community to see if current projects depending on FMP can be easily upgraded to use JKube. As part of the strategy to seek this feedback we are creating PRs on those repositories which we know are currently using FMP.

The current PR replaces the plugin dependency for FMP to Eclipse JKube and updates the README steps accordingly.

Final 1.0.0 is scheduled to be released on 2020-09-09. Nonetheless, this release candidate is stable enough, so this PR can be safely merged. After final release is available, we'll either update this PR or create a new one with the updated JKube version if this one was merged.