### PR TITLE
Issue 635

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
@@ -71,10 +71,10 @@ public class ConfigReloadAutoConfiguration {
 		@Autowired
 		private KubernetesClient kubernetesClient;
 
-		@Autowired
+		@Autowired(required = false)
 		private ConfigMapPropertySourceLocator configMapPropertySourceLocator;
 
-		@Autowired
+		@Autowired(required = false)
 		private SecretsPropertySourceLocator secretsPropertySourceLocator;
 
 		/**

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfi
 import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -84,8 +85,9 @@ public class ConfigReloadAutoConfiguration {
 		 */
 		@Bean
 		@ConditionalOnMissingBean
-		public ConfigurationChangeDetector propertyChangeWatcher(ConfigReloadProperties properties,
-				ConfigurationUpdateStrategy strategy) {
+		@ConditionalOnExpression("${spring.cloud.kubernetes.config.enabled:true} or ${spring.cloud.kubernetes.secrets.enabled:true}")
+		public ConfigurationChangeDetector propertyChangeWatcher(
+				ConfigReloadProperties properties, ConfigurationUpdateStrategy strategy) {
 			switch (properties.getMode()) {
 			case POLLING:
 				return new PollingConfigurationChangeDetector(this.environment, properties, this.kubernetesClient,

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadDefaultAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadDefaultAutoConfiguration.java
@@ -56,10 +56,10 @@ public class ConfigReloadDefaultAutoConfiguration {
 		@Autowired
 		private KubernetesClient kubernetesClient;
 
-		@Autowired
+		@Autowired(required = false)
 		private ConfigMapPropertySourceLocator configMapPropertySourceLocator;
 
-		@Autowired
+		@Autowired(required = false)
 		private SecretsPropertySourceLocator secretsPropertySourceLocator;
 
 		/**

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetector.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetector.java
@@ -65,7 +65,8 @@ public class EventBasedConfigurationChangeDetector extends ConfigurationChangeDe
 	public void watch() {
 		boolean activated = false;
 
-		if (this.properties.isMonitoringConfigMaps()) {
+		if (this.properties.isMonitoringConfigMaps()
+				&& this.configMapPropertySourceLocator != null) {
 			try {
 				String name = "config-maps-watch";
 				this.watches.put(name, this.kubernetesClient.configMaps().watch(new Watcher<ConfigMap>() {
@@ -91,7 +92,8 @@ public class EventBasedConfigurationChangeDetector extends ConfigurationChangeDe
 			}
 		}
 
-		if (this.properties.isMonitoringSecrets()) {
+		if (this.properties.isMonitoringSecrets()
+				&& this.secretsPropertySourceLocator != null) {
 			try {
 				activated = false;
 				String name = "secrets-watch";

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/PollingConfigurationChangeDetector.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/PollingConfigurationChangeDetector.java
@@ -67,7 +67,8 @@ public class PollingConfigurationChangeDetector extends ConfigurationChangeDetec
 	public void executeCycle() {
 
 		boolean changedConfigMap = false;
-		if (this.properties.isMonitoringConfigMaps()) {
+		if (this.properties.isMonitoringConfigMaps()
+				&& this.configMapPropertySourceLocator != null) {
 			List<? extends MapPropertySource> currentConfigMapSources = findPropertySources(
 					ConfigMapPropertySource.class);
 
@@ -79,9 +80,10 @@ public class PollingConfigurationChangeDetector extends ConfigurationChangeDetec
 		}
 
 		boolean changedSecrets = false;
-		if (this.properties.isMonitoringSecrets()) {
-			List<MapPropertySource> currentSecretSources = locateMapPropertySources(this.secretsPropertySourceLocator,
-					this.environment);
+		if (this.properties.isMonitoringSecrets()
+				&& this.secretsPropertySourceLocator != null) {
+			List<MapPropertySource> currentSecretSources = locateMapPropertySources(
+					this.secretsPropertySourceLocator, this.environment);
 			if (currentSecretSources != null && !currentSecretSources.isEmpty()) {
 				List<SecretsPropertySource> propertySources = findPropertySources(SecretsPropertySource.class);
 				changedSecrets = changed(currentSecretSources, propertySources);

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -51,22 +51,27 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigAndSecretsDisabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=false");
+	public void kubernetesWhenKubernetesConfigAndSecretDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=false");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigEnabledButSecretsDisabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=true", "spring.cloud.kubernetes.secrets.enabled=false");
+	public void kubernetesWhenKubernetesConfigEnabledButSecretDisabled()
+			throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=true",
+				"spring.cloud.kubernetes.secrets.enabled=false");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigDisabledButSecretsEnabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=true");
+	public void kubernetesWhenKubernetesConfigDisabledButSecretEnabled()
+			throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=true");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
 	}
@@ -79,9 +84,11 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	private void setup(String... env) {
-		this.context = new SpringApplicationBuilder(PropertyPlaceholderAutoConfiguration.class,
+		this.context = new SpringApplicationBuilder(
+				PropertyPlaceholderAutoConfiguration.class,
 				KubernetesClientTestConfiguration.class, BootstrapConfiguration.class)
-						.web(org.springframework.boot.WebApplicationType.NONE).properties(env).run();
+						.web(org.springframework.boot.WebApplicationType.NONE)
+						.properties(env).run();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -51,11 +51,24 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigDisabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=false",
-				"spring.cloud.kubernetes.secrets.enabled=false");
+	public void kubernetesWhenKubernetesConfigAndSecretDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=false");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
+	}
+
+	@Test
+	public void kubernetesWhenKubernetesConfigEnabledButSecretDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=true", "spring.cloud.kubernetes.secrets.enabled=false");
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
+	}
+
+	@Test
+	public void kubernetesWhenKubernetesConfigDisabledButSecretEnabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=true");
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
 	}
 
 	@Test
@@ -66,11 +79,9 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	private void setup(String... env) {
-		this.context = new SpringApplicationBuilder(
-				PropertyPlaceholderAutoConfiguration.class,
+		this.context = new SpringApplicationBuilder(PropertyPlaceholderAutoConfiguration.class,
 				KubernetesClientTestConfiguration.class, BootstrapConfiguration.class)
-						.web(org.springframework.boot.WebApplicationType.NONE)
-						.properties(env).run();
+						.web(org.springframework.boot.WebApplicationType.NONE).properties(env).run();
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Fixes #635 

1. Makes Autowired dependencies under ConfigReloadAutoConfiguration and ConfigReloadDefaultAutoConfiguration optional. That way it is consistent with conditionals on BootstrapConfiguration. The ConfigurationChangeDetector/watcher downstream honors configs for configMap or secret and registers a watcher as expected.
2. Adds tests for use-cases where either config and/or secret is enabled or vice-versa 