### PR TITLE
Issue #635 - Decouples configMap and secret property source locators by making the…

### DIFF
--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfi
 import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -84,6 +85,7 @@ public class ConfigReloadAutoConfiguration {
 		 */
 		@Bean
 		@ConditionalOnMissingBean
+		@ConditionalOnExpression("${spring.cloud.kubernetes.config.enabled:true} or ${spring.cloud.kubernetes.secrets.enabled:true}")
 		public ConfigurationChangeDetector propertyChangeWatcher(
 				ConfigReloadProperties properties, ConfigurationUpdateStrategy strategy) {
 			switch (properties.getMode()) {

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
@@ -71,10 +71,10 @@ public class ConfigReloadAutoConfiguration {
 		@Autowired
 		private KubernetesClient kubernetesClient;
 
-		@Autowired
+		@Autowired(required = false)
 		private ConfigMapPropertySourceLocator configMapPropertySourceLocator;
 
-		@Autowired
+		@Autowired(required = false)
 		private SecretsPropertySourceLocator secretsPropertySourceLocator;
 
 		/**

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigReloadAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -37,6 +38,7 @@ import org.springframework.cloud.kubernetes.config.ConfigMapPropertySourceLocato
 import org.springframework.cloud.kubernetes.config.SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.AbstractEnvironment;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -78,16 +80,13 @@ public class ConfigReloadAutoConfiguration {
 		 * @return a bean that listen to configuration changes and fire a reload.
 		 */
 		@Bean
-		@ConditionalOnMissingBean
-		@ConditionalOnBean({ ConfigMapPropertySourceLocator.class,
-				SecretsPropertySourceLocator.class })
+		@Conditional(OnConfigEnabledOrSecretsEnabled.class)
 		public ConfigurationChangeDetector propertyChangeWatcher(
 				ConfigReloadProperties properties, ConfigurationUpdateStrategy strategy,
 				@Autowired(
 						required = false) ConfigMapPropertySourceLocator configMapPropertySourceLocator,
 				@Autowired(
 						required = false) SecretsPropertySourceLocator secretsPropertySourceLocator) {
-			System.out.println("init propertyChangeWatcher");
 			switch (properties.getMode()) {
 			case POLLING:
 				return new PollingConfigurationChangeDetector(this.environment,
@@ -145,6 +144,24 @@ public class ConfigReloadAutoConfiguration {
 			}
 			catch (InterruptedException ignored) {
 			}
+		}
+
+		private static class OnConfigEnabledOrSecretsEnabled extends AnyNestedCondition {
+
+			OnConfigEnabledOrSecretsEnabled() {
+				super(ConfigurationPhase.REGISTER_BEAN);
+			}
+
+			@ConditionalOnBean(ConfigMapPropertySourceLocator.class)
+			static class configEnabled {
+
+			}
+
+			@ConditionalOnBean(SecretsPropertySourceLocator.class)
+			static class secretsEnabled {
+
+			}
+
 		}
 
 	}

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetector.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/EventBasedConfigurationChangeDetector.java
@@ -66,7 +66,8 @@ public class EventBasedConfigurationChangeDetector extends ConfigurationChangeDe
 	public void watch() {
 		boolean activated = false;
 
-		if (this.properties.isMonitoringConfigMaps()) {
+		if (this.properties.isMonitoringConfigMaps()
+				&& this.configMapPropertySourceLocator != null) {
 			try {
 				String name = "config-maps-watch";
 				this.watches.put(name, this.kubernetesClient.configMaps()
@@ -91,7 +92,8 @@ public class EventBasedConfigurationChangeDetector extends ConfigurationChangeDe
 			}
 		}
 
-		if (this.properties.isMonitoringSecrets()) {
+		if (this.properties.isMonitoringSecrets()
+				&& this.secretsPropertySourceLocator != null) {
 			try {
 				activated = false;
 				String name = "secrets-watch";

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/PollingConfigurationChangeDetector.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/PollingConfigurationChangeDetector.java
@@ -68,7 +68,8 @@ public class PollingConfigurationChangeDetector extends ConfigurationChangeDetec
 	public void executeCycle() {
 
 		boolean changedConfigMap = false;
-		if (this.properties.isMonitoringConfigMaps()) {
+		if (this.properties.isMonitoringConfigMaps()
+				&& this.configMapPropertySourceLocator != null) {
 			List<? extends MapPropertySource> currentConfigMapSources = findPropertySources(
 					ConfigMapPropertySource.class);
 
@@ -81,7 +82,8 @@ public class PollingConfigurationChangeDetector extends ConfigurationChangeDetec
 		}
 
 		boolean changedSecrets = false;
-		if (this.properties.isMonitoringSecrets()) {
+		if (this.properties.isMonitoringSecrets()
+				&& this.secretsPropertySourceLocator != null) {
 			List<MapPropertySource> currentSecretSources = locateMapPropertySources(
 					this.secretsPropertySourceLocator, this.environment);
 			if (currentSecretSources != null && !currentSecretSources.isEmpty()) {

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.cloud.kubernetes.config.reload.ConfigReloadAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -95,7 +97,8 @@ public class KubernetesConfigConfigurationTest {
 	private void setup(String... env) {
 		this.context = new SpringApplicationBuilder(
 				PropertyPlaceholderAutoConfiguration.class,
-				KubernetesClientTestConfiguration.class, BootstrapConfiguration.class)
+				KubernetesClientTestConfiguration.class, BootstrapConfiguration.class,
+				ConfigReloadAutoConfiguration.class, RefreshAutoConfiguration.class)
 						.web(org.springframework.boot.WebApplicationType.NONE)
 						.properties(env).run();
 	}

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -52,21 +52,26 @@ public class KubernetesConfigConfigurationTest {
 
 	@Test
 	public void kubernetesWhenKubernetesConfigAndSecretDisabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=false");
+		setup("spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=false");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigEnabledButSecretDisabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=true", "spring.cloud.kubernetes.secrets.enabled=false");
+	public void kubernetesWhenKubernetesConfigEnabledButSecretDisabled()
+			throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=true",
+				"spring.cloud.kubernetes.secrets.enabled=false");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigDisabledButSecretEnabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=true");
+	public void kubernetesWhenKubernetesConfigDisabledButSecretEnabled()
+			throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=true");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
 	}
@@ -79,9 +84,11 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	private void setup(String... env) {
-		this.context = new SpringApplicationBuilder(PropertyPlaceholderAutoConfiguration.class,
+		this.context = new SpringApplicationBuilder(
+				PropertyPlaceholderAutoConfiguration.class,
 				KubernetesClientTestConfiguration.class, BootstrapConfiguration.class)
-						.web(org.springframework.boot.WebApplicationType.NONE).properties(env).run();
+						.web(org.springframework.boot.WebApplicationType.NONE)
+						.properties(env).run();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -94,6 +94,28 @@ public class KubernetesConfigConfigurationTest {
 		assertThat(this.context.containsBean("propertyChangeWatcher")).isTrue();
 	}
 
+	@Test
+	public void kubernetesReloadEnabledButSecretDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.enabled=true",
+				"spring.cloud.kubernetes.config.enabled=true",
+				"spring.cloud.kubernetes.secrets.enabled=false",
+				"spring.cloud.kubernetes.reload.enabled=true");
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
+		assertThat(this.context.containsBean("propertyChangeWatcher")).isTrue();
+	}
+
+	@Test
+	public void kubernetesReloadEnabledButSecretAndConfigDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.enabled=true",
+				"spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=false",
+				"spring.cloud.kubernetes.reload.enabled=true");
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
+		assertThat(this.context.containsBean("propertyChangeWatcher")).isFalse();
+	}
+
 	private void setup(String... env) {
 		this.context = new SpringApplicationBuilder(
 				PropertyPlaceholderAutoConfiguration.class,

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -89,8 +89,6 @@ public class KubernetesConfigConfigurationTest {
 	public void kubernetesReloadEnabled() throws Exception {
 		setup("spring.cloud.kubernetes.enabled=true",
 				"spring.cloud.kubernetes.reload.enabled=true");
-		System.out.println(
-				"bean names == " + Arrays.asList(this.context.getBeanDefinitionNames()));
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
 		assertThat(this.context.containsBean("propertyChangeWatcher")).isTrue();

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.kubernetes.config;
 
+import java.util.Arrays;
+
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.After;
 import org.junit.Test;
@@ -81,6 +83,17 @@ public class KubernetesConfigConfigurationTest {
 		setup("spring.cloud.kubernetes.enabled=true");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
+	}
+
+	@Test
+	public void kubernetesReloadEnabled() throws Exception {
+		setup("spring.cloud.kubernetes.enabled=true",
+				"spring.cloud.kubernetes.reload.enabled=true");
+		System.out.println(
+				"bean names == " + Arrays.asList(this.context.getBeanDefinitionNames()));
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
+		assertThat(this.context.containsBean("propertyChangeWatcher")).isTrue();
 	}
 
 	private void setup(String... env) {

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -51,11 +51,24 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigDisabled() throws Exception {
-		setup("spring.cloud.kubernetes.config.enabled=false",
-				"spring.cloud.kubernetes.secrets.enabled=false");
+	public void kubernetesWhenKubernetesConfigAndSecretDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=false");
 		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
+	}
+
+	@Test
+	public void kubernetesWhenKubernetesConfigEnabledButSecretDisabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=true", "spring.cloud.kubernetes.secrets.enabled=false");
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isTrue();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isFalse();
+	}
+
+	@Test
+	public void kubernetesWhenKubernetesConfigDisabledButSecretEnabled() throws Exception {
+		setup("spring.cloud.kubernetes.config.enabled=false", "spring.cloud.kubernetes.secrets.enabled=true");
+		assertThat(this.context.containsBean("configMapPropertySourceLocator")).isFalse();
+		assertThat(this.context.containsBean("secretsPropertySourceLocator")).isTrue();
 	}
 
 	@Test
@@ -66,11 +79,9 @@ public class KubernetesConfigConfigurationTest {
 	}
 
 	private void setup(String... env) {
-		this.context = new SpringApplicationBuilder(
-				PropertyPlaceholderAutoConfiguration.class,
+		this.context = new SpringApplicationBuilder(PropertyPlaceholderAutoConfiguration.class,
 				KubernetesClientTestConfiguration.class, BootstrapConfiguration.class)
-						.web(org.springframework.boot.WebApplicationType.NONE)
-						.properties(env).run();
+						.web(org.springframework.boot.WebApplicationType.NONE).properties(env).run();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/KubernetesConfigConfigurationTest.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.kubernetes.config;
 
-import java.util.Arrays;
-
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.After;
 import org.junit.Test;


### PR DESCRIPTION
…m optional dependencies for reload auto config as they could be enabled/disabled through config independent of each other. Fixes #635

**Describe the bug**

Attempting to configure  spring-cloud-kubernetes-config to just add support for kubernetes configMaps. (and disable secrets and discovery client) However would like to support config reload with event. It appears that when bringing up spring boot with the configuration below along with AutoConfigure, we run into a  bean resolution issue as posted below.

**Sample Configuration**

```
spring:
  cloud:
    kubernetes:
      config:
        enabled: true
      secrets:
        enabled: false
      discovery:
        enabled: false
      reload:
        enabled: true
        monitoring-config-maps: true
```

Exception:

```
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'org.springframework.cloud.kubernetes.config.reload.ConfigReloadAutoConfiguration$ConfigReloadAutoConfigurationBeans': Unsatisfied dependency expressed through field 'secretsPropertySourceLocator'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.cloud.kubernetes.config.SecretsPropertySourceLocator' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {@org.springframework.beans.factory.annotation.Autowired(required=true)}
```

If the above seems a valid set of configs, Ideally, i would expect the configuration flags that either define or not define a given bean to be honored for autoconfigs as well.

Tested with:

```
Spring Boot: 2.3.3.RELEASE
spring-cloud-kubernetes-config: 1.1.3.RELEASE
```
