### PR TITLE
Allow loading of config maps to be retried on failure

### DIFF
--- a/spring-cloud-kubernetes-config/pom.xml
+++ b/spring-cloud-kubernetes-config/pom.xml
@@ -68,6 +68,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<!-- Only needed at compile time -->

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/BootstrapConfiguration.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/BootstrapConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.kubernetes.config;
 
+import java.util.Optional;
+
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -30,8 +32,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.retry.support.RetryTemplate;
-
-import java.util.Optional;
 
 /**
  * Auto configuration that reuses Kubernetes config maps as property sources.
@@ -53,8 +53,10 @@ public class BootstrapConfiguration {
 
 		@Bean
 		@ConditionalOnProperty(name = "spring.cloud.kubernetes.config.enabled", matchIfMissing = true)
-		public ConfigMapPropertySourceLocator configMapPropertySourceLocator(ConfigMapConfigProperties properties, Optional<ConfigMapRetryTemplateFactory> configMapRetryTemplateFactory) {
-			return new ConfigMapPropertySourceLocator(this.client, properties, configMapRetryTemplateFactory.orElse(null));
+		public ConfigMapPropertySourceLocator configMapPropertySourceLocator(ConfigMapConfigProperties properties,
+				Optional<ConfigMapRetryTemplateFactory> configMapRetryTemplateFactory) {
+			return new ConfigMapPropertySourceLocator(this.client, properties,
+					configMapRetryTemplateFactory.orElse(null));
 		}
 
 		@Bean
@@ -67,13 +69,11 @@ public class BootstrapConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnClass(RetryTemplate.class)
 		public ConfigMapRetryTemplateFactory configMapRetryPolicyFactory(ConfigMapConfigProperties properties) {
-			final RetryTemplate template = RetryTemplate.builder()
-				.maxAttempts(properties.getRetry().getMaxAttempts())
-				.fixedBackoff(properties.getRetry().getBackoff().toMillis())
-				.retryOn(Exception.class)
-				.build();
+			final RetryTemplate template = RetryTemplate.builder().maxAttempts(properties.getRetry().getMaxAttempts())
+					.fixedBackoff(properties.getRetry().getBackoff().toMillis()).retryOn(Exception.class).build();
 			return () -> template;
 		}
+
 	}
 
 }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.kubernetes.config;
 
-import java.util.Collections;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -85,9 +85,8 @@ public class ConfigMapConfigProperties extends AbstractConfigProperties {
 	 */
 	public List<NormalizedSource> determineSources() {
 		if (this.sources.isEmpty()) {
-			return Collections.singletonList(
-					new NormalizedSource(ConfigMapConfigProperties.this.name,
-							ConfigMapConfigProperties.this.namespace));
+			return Collections.singletonList(new NormalizedSource(ConfigMapConfigProperties.this.name,
+					ConfigMapConfigProperties.this.namespace));
 		}
 
 		return this.sources.stream().map(s -> s.normalize(this.name, this.namespace)).collect(Collectors.toList());

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
@@ -180,6 +180,7 @@ public class ConfigMapConfigProperties extends AbstractConfigProperties {
 		public void setBackoff(Duration backoff) {
 			this.backoff = backoff;
 		}
+
 	}
 
 	static class NormalizedSource {

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapConfigProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.kubernetes.config;
 
 import java.util.Collections;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +28,7 @@ import org.springframework.util.StringUtils;
  * Config map configuration properties.
  *
  * @author Ioannis Canellos
+ * @author Roy Jacobs
  */
 @ConfigurationProperties("spring.cloud.kubernetes.config")
 public class ConfigMapConfigProperties extends AbstractConfigProperties {
@@ -38,6 +40,8 @@ public class ConfigMapConfigProperties extends AbstractConfigProperties {
 	private List<String> paths = Collections.emptyList();
 
 	private List<Source> sources = Collections.emptyList();
+
+	private Retry retry = new Retry();
 
 	public boolean isEnableApi() {
 		return this.enableApi;
@@ -61,6 +65,14 @@ public class ConfigMapConfigProperties extends AbstractConfigProperties {
 
 	public void setSources(List<Source> sources) {
 		this.sources = sources;
+	}
+
+	public Retry getRetry() {
+		return retry;
+	}
+
+	public void setRetry(Retry retry) {
+		this.retry = retry;
 	}
 
 	/**
@@ -136,6 +148,38 @@ public class ConfigMapConfigProperties extends AbstractConfigProperties {
 			return new NormalizedSource(normalizedName, normalizedNamespace);
 		}
 
+	}
+
+	public static class Retry {
+
+		/**
+		 * The amount of times to try contacting Kubernetes to load config maps.
+		 */
+		private int maxAttempts = 3;
+
+		/**
+		 * The delay in between attempts to load config maps.
+		 */
+		private Duration backoff = Duration.ofSeconds(1);
+
+		public Retry() {
+		}
+
+		public int getMaxAttempts() {
+			return maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
+		}
+
+		public Duration getBackoff() {
+			return backoff;
+		}
+
+		public void setBackoff(Duration backoff) {
+			this.backoff = backoff;
+		}
 	}
 
 	static class NormalizedSource {

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySource.java
@@ -76,8 +76,10 @@ public class ConfigMapPropertySource extends MapPropertySource {
 		this(client, name, namespace, environment, null);
 	}
 
-	public ConfigMapPropertySource(KubernetesClient client, String name, String namespace, Environment environment, ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
-		super(getName(client, name, namespace), asObjectMap(getData(client, name, namespace, environment, configMapRetryTemplateFactory)));
+	public ConfigMapPropertySource(KubernetesClient client, String name, String namespace, Environment environment,
+			ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
+		super(getName(client, name, namespace),
+				asObjectMap(getData(client, name, namespace, environment, configMapRetryTemplateFactory)));
 	}
 
 	private static String getName(KubernetesClient client, String name, String namespace) {
@@ -87,18 +89,20 @@ public class ConfigMapPropertySource extends MapPropertySource {
 	}
 
 	private static Map<String, Object> getData(KubernetesClient client, String name, String namespace,
-											   Environment environment, ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
+			Environment environment, ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
 		try {
 			if (configMapRetryTemplateFactory == null) {
 				return tryGetData(client, name, namespace, environment);
-			} else {
+			}
+			else {
 				final RetryTemplate retryTemplate = configMapRetryTemplateFactory.getRetryTemplate();
 				return retryTemplate.execute(ctx -> {
 					try {
 						return tryGetData(client, name, namespace, environment);
 					}
 					catch (Exception e) {
-						LOG.warn("Can't read configMap with name: [" + name + "] in namespace:[" + namespace + "]. Retrying.", e);
+						LOG.warn("Can't read configMap with name: [" + name + "] in namespace:[" + namespace
+								+ "]. Retrying.", e);
 						throw e;
 					}
 				});
@@ -112,7 +116,7 @@ public class ConfigMapPropertySource extends MapPropertySource {
 	}
 
 	private static Map<String, Object> tryGetData(KubernetesClient client, String name, String namespace,
-											   Environment environment) {
+			Environment environment) {
 		Map<String, Object> result = new LinkedHashMap<>();
 		ConfigMap map = StringUtils.isEmpty(namespace) ? client.configMaps().withName(name).get()
 				: client.configMaps().inNamespace(namespace).withName(name).get();

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -65,7 +65,8 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 		this(client, properties, null);
 	}
 
-	public ConfigMapPropertySourceLocator(KubernetesClient client, ConfigMapConfigProperties properties, ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
+	public ConfigMapPropertySourceLocator(KubernetesClient client, ConfigMapConfigProperties properties,
+			ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
 		this.client = client;
 		this.properties = properties;
 		this.configMapRetryTemplateFactory = configMapRetryTemplateFactory;
@@ -95,8 +96,8 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 		String configurationTarget = this.properties.getConfigurationTarget();
 		return new ConfigMapPropertySource(this.client,
 				getApplicationName(environment, normalizedSource.getName(), configurationTarget),
-				getApplicationNamespace(this.client, normalizedSource.getNamespace(), configurationTarget),
-				environment, configMapRetryTemplateFactory);
+				getApplicationNamespace(this.client, normalizedSource.getNamespace(), configurationTarget), environment,
+				configMapRetryTemplateFactory);
 	}
 
 	private void addPropertySourcesFromPaths(Environment environment, CompositePropertySource composite) {

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapPropertySourceLocator.java
@@ -48,6 +48,7 @@ import static org.springframework.cloud.kubernetes.config.PropertySourceUtils.ya
  *
  * @author Ioannis Canellos
  * @author Michael Moudatsos
+ * @author Roy Jacobs
  */
 @Order(0)
 public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
@@ -58,9 +59,16 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 
 	private final ConfigMapConfigProperties properties;
 
+	private final ConfigMapRetryTemplateFactory configMapRetryTemplateFactory;
+
 	public ConfigMapPropertySourceLocator(KubernetesClient client, ConfigMapConfigProperties properties) {
+		this(client, properties, null);
+	}
+
+	public ConfigMapPropertySourceLocator(KubernetesClient client, ConfigMapConfigProperties properties, ConfigMapRetryTemplateFactory configMapRetryTemplateFactory) {
 		this.client = client;
 		this.properties = properties;
+		this.configMapRetryTemplateFactory = configMapRetryTemplateFactory;
 	}
 
 	@Override
@@ -88,7 +96,7 @@ public class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 		return new ConfigMapPropertySource(this.client,
 				getApplicationName(environment, normalizedSource.getName(), configurationTarget),
 				getApplicationNamespace(this.client, normalizedSource.getNamespace(), configurationTarget),
-				environment);
+				environment, configMapRetryTemplateFactory);
 	}
 
 	private void addPropertySourcesFromPaths(Environment environment, CompositePropertySource composite) {

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapRetryTemplateFactory.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapRetryTemplateFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.config;
+
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * This interface determines which retry logic to apply if there are any errors during the loading of config maps
+ * at application startup.
+ *
+ * @author Roy Jacobs
+ */
+public interface ConfigMapRetryTemplateFactory {
+	/**
+	 * @return the {@link RetryTemplate} to use when loading config maps.
+	 */
+	RetryTemplate getRetryTemplate();
+}

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapRetryTemplateFactory.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigMapRetryTemplateFactory.java
@@ -19,14 +19,16 @@ package org.springframework.cloud.kubernetes.config;
 import org.springframework.retry.support.RetryTemplate;
 
 /**
- * This interface determines which retry logic to apply if there are any errors during the loading of config maps
- * at application startup.
+ * This interface determines which retry logic to apply if there are any errors during the
+ * loading of config maps at application startup.
  *
  * @author Roy Jacobs
  */
 public interface ConfigMapRetryTemplateFactory {
+
 	/**
 	 * @return the {@link RetryTemplate} to use when loading config maps.
 	 */
 	RetryTemplate getRetryTemplate();
+
 }

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigUtils.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/ConfigUtils.java
@@ -39,26 +39,21 @@ public final class ConfigUtils {
 		throw new IllegalStateException("Can't instantiate a utility class");
 	}
 
-	public static String getApplicationName(Environment env, String configName,
-			String configurationTarget) {
+	public static String getApplicationName(Environment env, String configName, String configurationTarget) {
 		if (StringUtils.isEmpty(configName)) {
 			// TODO: use relaxed binding
-			LOG.debug(configurationTarget
-					+ " name has not been set, taking it from property/env "
-					+ SPRING_APPLICATION_NAME + " (default=" + FALLBACK_APPLICATION_NAME
-					+ ")");
-			configName = env.getProperty(SPRING_APPLICATION_NAME,
-					FALLBACK_APPLICATION_NAME);
+			LOG.debug(configurationTarget + " name has not been set, taking it from property/env "
+					+ SPRING_APPLICATION_NAME + " (default=" + FALLBACK_APPLICATION_NAME + ")");
+			configName = env.getProperty(SPRING_APPLICATION_NAME, FALLBACK_APPLICATION_NAME);
 		}
 
 		return configName;
 	}
 
-	public static String getApplicationNamespace(KubernetesClient client,
-			String configNamespace, String configurationTarget) {
+	public static String getApplicationNamespace(KubernetesClient client, String configNamespace,
+			String configurationTarget) {
 		if (StringUtils.isEmpty(configNamespace)) {
-			LOG.debug(configurationTarget
-					+ " namespace has not been set, taking it from client (ns="
+			LOG.debug(configurationTarget + " namespace has not been set, taking it from client (ns="
 					+ client.getNamespace() + ")");
 			configNamespace = client.getNamespace();
 		}

--- a/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigurationChangeDetector.java
+++ b/spring-cloud-kubernetes-config/src/main/java/org/springframework/cloud/kubernetes/config/reload/ConfigurationChangeDetector.java
@@ -93,13 +93,11 @@ public abstract class ConfigurationChangeDetector {
 		return !Objects.equals(leftMap, rightMap);
 	}
 
-	protected boolean changed(List<? extends MapPropertySource> left,
-			List<? extends MapPropertySource> right) {
+	protected boolean changed(List<? extends MapPropertySource> left, List<? extends MapPropertySource> right) {
 
 		if (left.size() != right.size()) {
-			this.log.warn(
-					"The current number of ConfigMap PropertySources does not match "
-							+ "the ones loaded from the Kubernetes - No reload will take place");
+			this.log.warn("The current number of ConfigMap PropertySources does not match "
+					+ "the ones loaded from the Kubernetes - No reload will take place");
 			return false;
 		}
 
@@ -148,8 +146,7 @@ public abstract class ConfigurationChangeDetector {
 				managedSources.add(sourceClass.cast(source));
 			}
 			else if (source instanceof BootstrapPropertySource) {
-				PropertySource<?> propertySource = ((BootstrapPropertySource<?>) source)
-						.getDelegate();
+				PropertySource<?> propertySource = ((BootstrapPropertySource<?>) source).getDelegate();
 				if (sourceClass.isInstance(propertySource)) {
 					sources.add(propertySource);
 				}
@@ -184,10 +181,8 @@ public abstract class ConfigurationChangeDetector {
 			result.add((MapPropertySource) propertySource);
 		}
 		else if (propertySource instanceof CompositePropertySource) {
-			result.addAll(((CompositePropertySource) propertySource).getPropertySources()
-					.stream()
-					.filter(p -> p instanceof MapPropertySource)
-					.map(p -> (MapPropertySource) p)
+			result.addAll(((CompositePropertySource) propertySource).getPropertySources().stream()
+					.filter(p -> p instanceof MapPropertySource).map(p -> (MapPropertySource) p)
 					.collect(Collectors.toList()));
 		}
 		else {

--- a/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/reload/ConfigurationChangeDetectorTest.java
+++ b/spring-cloud-kubernetes-config/src/test/java/org/springframework/cloud/kubernetes/config/reload/ConfigurationChangeDetectorTest.java
@@ -33,8 +33,7 @@ import org.springframework.core.env.MapPropertySource;
  */
 public class ConfigurationChangeDetectorTest {
 
-	private final ConfigurationChangeDetectorStub stub = new ConfigurationChangeDetectorStub(
-			null, null, null, null);
+	private final ConfigurationChangeDetectorStub stub = new ConfigurationChangeDetectorStub(null, null, null, null);
 
 	@Test
 	public void testChangedTwoNulls() {
@@ -44,16 +43,14 @@ public class ConfigurationChangeDetectorTest {
 
 	@Test
 	public void testChangedLeftNullRightNonNull() {
-		MapPropertySource right = new MapPropertySource("rightNonNull",
-				Collections.emptyMap());
+		MapPropertySource right = new MapPropertySource("rightNonNull", Collections.emptyMap());
 		boolean changed = stub.changed(null, right);
 		Assert.assertTrue(changed);
 	}
 
 	@Test
 	public void testChangedLeftNonNullRightNull() {
-		MapPropertySource left = new MapPropertySource("leftNonNull",
-				Collections.emptyMap());
+		MapPropertySource left = new MapPropertySource("leftNonNull", Collections.emptyMap());
 		boolean changed = stub.changed(left, null);
 		Assert.assertTrue(changed);
 	}
@@ -87,8 +84,7 @@ public class ConfigurationChangeDetectorTest {
 
 	@Test
 	public void testChangedListsDifferentSizes() {
-		List<MapPropertySource> left = Collections
-				.singletonList(new MapPropertySource("one", Collections.emptyMap()));
+		List<MapPropertySource> left = Collections.singletonList(new MapPropertySource("one", Collections.emptyMap()));
 		List<MapPropertySource> right = Collections.emptyList();
 		boolean changed = stub.changed(left, right);
 		Assert.assertFalse(changed);
@@ -101,10 +97,8 @@ public class ConfigurationChangeDetectorTest {
 		leftMap.put("key", value);
 		Map<String, Object> rightMap = new HashMap<>();
 		leftMap.put("anotherKey", value);
-		List<MapPropertySource> left = Collections
-				.singletonList(new MapPropertySource("one", leftMap));
-		List<MapPropertySource> right = Collections
-				.singletonList(new MapPropertySource("two", rightMap));
+		List<MapPropertySource> left = Collections.singletonList(new MapPropertySource("one", leftMap));
+		List<MapPropertySource> right = Collections.singletonList(new MapPropertySource("two", rightMap));
 		boolean changed = stub.changed(left, right);
 		Assert.assertTrue(changed);
 	}
@@ -116,10 +110,8 @@ public class ConfigurationChangeDetectorTest {
 		leftMap.put("key", value);
 		Map<String, Object> rightMap = new HashMap<>();
 		leftMap.put("key", value);
-		List<MapPropertySource> left = Collections
-				.singletonList(new MapPropertySource("one", leftMap));
-		List<MapPropertySource> right = Collections
-				.singletonList(new MapPropertySource("two", rightMap));
+		List<MapPropertySource> left = Collections.singletonList(new MapPropertySource("one", leftMap));
+		List<MapPropertySource> right = Collections.singletonList(new MapPropertySource("two", rightMap));
 		boolean changed = stub.changed(left, right);
 		Assert.assertTrue(changed);
 	}
@@ -127,12 +119,10 @@ public class ConfigurationChangeDetectorTest {
 	/**
 	 * only needed to test some protected methods it defines
 	 */
-	private static final class ConfigurationChangeDetectorStub
-			extends ConfigurationChangeDetector {
+	private static final class ConfigurationChangeDetectorStub extends ConfigurationChangeDetector {
 
-		private ConfigurationChangeDetectorStub(ConfigurableEnvironment environment,
-				ConfigReloadProperties properties, KubernetesClient kubernetesClient,
-				ConfigurationUpdateStrategy strategy) {
+		private ConfigurationChangeDetectorStub(ConfigurableEnvironment environment, ConfigReloadProperties properties,
+				KubernetesClient kubernetesClient, ConfigurationUpdateStrategy strategy) {
 			super(environment, properties, kubernetesClient, strategy);
 		}
 

--- a/spring-cloud-kubernetes-dependencies/pom.xml
+++ b/spring-cloud-kubernetes-dependencies/pom.xml
@@ -39,6 +39,7 @@
 		<istio-client.version>1.1.1</istio-client.version>
 		<mockwebserver.version>0.1.2</mockwebserver.version>
 		<okhttp.version>3.14.4</okhttp.version>
+		<spring-retry.version>1.3.0</spring-retry.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -54,6 +55,12 @@
 				<groupId>me.snowdrop</groupId>
 				<artifactId>istio-client</artifactId>
 				<version>${istio-client.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.retry</groupId>
+				<artifactId>spring-retry</artifactId>
+				<version>${spring-retry.version}</version>
 			</dependency>
 
 			<!-- Own dependencies -->


### PR DESCRIPTION
I'm trying to solve https://github.com/spring-cloud/spring-cloud-kubernetes/issues/441. There was already a pull request (https://github.com/spring-cloud/spring-cloud-kubernetes/pull/446) for this, but it stalled. Instead of rebasing that PR I've tried to simply add a wrapper around spring-retry, since the discussion in that pull request seemed to indicate this is a valid approach.

Can you confirm this approach would be ok for you? If so, I will spend some more time on the PR adding appropriate tests. Otherwise I'm open to changing directions.

The reason I didn't try to abstract away `spring-retry` is that it's a fairly well known project in the Spring ecosystem and it felt unnecessary to hide that. The configuration is set up so that if the dependency is not available retry logic will simply be unavailable and the old behaviour will be used.