### PR TITLE
This bean should be considered only when app is running in kubernetes

### DIFF
--- a/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/IstioAutoConfiguration.java
+++ b/spring-cloud-kubernetes-istio/src/main/java/org/springframework/cloud/kubernetes/istio/IstioAutoConfiguration.java
@@ -22,6 +22,7 @@ import me.snowdrop.istio.client.IstioClient;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.kubernetes.ConditionalOnKubernetesEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.cloud.istio.enabled", matchIfMissing = true)
+@ConditionalOnKubernetesEnabled
 public class IstioAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
When spring boot app runs on bare metal, you get an error: No qualifying bean of type 'io.fabric8.kubernetes.client.Config' available.