### PR TITLE
Enable the kubernetes profile without API requests

### DIFF
--- a/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/profile/KubernetesClientProfileEnvironmentPostProcessor.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/profile/KubernetesClientProfileEnvironmentPostProcessor.java
@@ -24,15 +24,17 @@ import org.springframework.core.env.Environment;
 
 /**
  * @author Ryan Baxter
+ * @author Thomas Vitale
  */
 public class KubernetesClientProfileEnvironmentPostProcessor extends AbstractKubernetesProfileEnvironmentPostProcessor {
+
+	protected static final String KUBERNETES_SERVICE_ENV_VAR = "KUBERNETES_SERVICE_HOST";
 
 	@Override
 	protected boolean isInsideKubernetes(Environment environment) {
 		CoreV1Api api = new CoreV1Api();
 		KubernetesClientPodUtils utils = new KubernetesClientPodUtils(api, environment.getProperty(NAMESPACE_PROPERTY));
-		return utils.isInsideKubernetes();
-
+		return environment.containsProperty(KUBERNETES_SERVICE_ENV_VAR) || utils.isInsideKubernetes();
 	}
 
 }

--- a/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/profile/KubernetesClientProfileEnvironmentPostProcessorTests.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/profile/KubernetesClientProfileEnvironmentPostProcessorTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.profile;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.kubernetes.commons.profile.AbstractKubernetesProfileEnvironmentPostProcessor.KUBERNETES_PROFILE;
+
+/**
+ * @author Thomas Vitale
+ */
+class KubernetesClientProfileEnvironmentPostProcessorTests {
+
+	@Test
+	void whenKubernetesEnvironmentAndNoApiAccessThenProfileEnabled() {
+		ConfigurableApplicationContext context = new SpringApplicationBuilder(App.class)
+			.web(org.springframework.boot.WebApplicationType.NONE)
+			.properties("KUBERNETES_SERVICE_HOST=10.0.0.1")
+			.run();
+
+		assertThat(context.getEnvironment().getActiveProfiles()).contains(KUBERNETES_PROFILE);
+	}
+
+	@Test
+	void whenNoKubernetesEnvironmentAndNoApiAccessThenNoProfileEnabled() {
+		ConfigurableApplicationContext context = new SpringApplicationBuilder(App.class)
+			.web(org.springframework.boot.WebApplicationType.NONE)
+			.run();
+
+		assertThat(context.getEnvironment().getActiveProfiles()).doesNotContain(KUBERNETES_PROFILE);
+	}
+
+	@SpringBootApplication
+	static class App {
+	}
+}

--- a/spring-cloud-kubernetes-fabric8-autoconfig/src/main/java/org/springframework/cloud/kubernetes/fabric8/profile/Fabric8ProfileEnvironmentPostProcessor.java
+++ b/spring-cloud-kubernetes-fabric8-autoconfig/src/main/java/org/springframework/cloud/kubernetes/fabric8/profile/Fabric8ProfileEnvironmentPostProcessor.java
@@ -24,11 +24,13 @@ import org.springframework.core.env.Environment;
 
 public class Fabric8ProfileEnvironmentPostProcessor extends AbstractKubernetesProfileEnvironmentPostProcessor {
 
+	protected static final String KUBERNETES_SERVICE_ENV_VAR = "KUBERNETES_SERVICE_HOST";
+
 	@Override
 	protected boolean isInsideKubernetes(Environment environment) {
 		try (DefaultKubernetesClient client = new DefaultKubernetesClient()) {
 			final Fabric8PodUtils podUtils = new Fabric8PodUtils(client);
-			return podUtils.isInsideKubernetes();
+			return environment.containsProperty(KUBERNETES_SERVICE_ENV_VAR) || podUtils.isInsideKubernetes();
 		}
 	}
 

--- a/spring-cloud-kubernetes-fabric8-autoconfig/src/test/java/org/springframework/cloud/kubernetes/fabric8/profile/Fabric8ProfileEnvironmentPostProcessorTests.java
+++ b/spring-cloud-kubernetes-fabric8-autoconfig/src/test/java/org/springframework/cloud/kubernetes/fabric8/profile/Fabric8ProfileEnvironmentPostProcessorTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.profile;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.kubernetes.example.App;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.kubernetes.commons.profile.AbstractKubernetesProfileEnvironmentPostProcessor.KUBERNETES_PROFILE;
+
+/**
+ * @author Thomas Vitale
+ */
+class Fabric8ProfileEnvironmentPostProcessorTests {
+
+	@Test
+	void whenKubernetesEnvironmentAndNoApiAccessThenProfileEnabled() {
+		ConfigurableApplicationContext context = new SpringApplicationBuilder(App.class)
+			.web(org.springframework.boot.WebApplicationType.NONE)
+			.properties("KUBERNETES_SERVICE_HOST=10.0.0.1")
+			.run();
+
+		assertThat(context.getEnvironment().getActiveProfiles()).contains(KUBERNETES_PROFILE);
+	}
+
+	@Test
+	void whenNoKubernetesEnvironmentAndNoApiAccessThenNoProfileEnabled() {
+		ConfigurableApplicationContext context = new SpringApplicationBuilder(App.class)
+			.web(org.springframework.boot.WebApplicationType.NONE).run();
+
+		assertThat(context.getEnvironment().getActiveProfiles()).doesNotContain(KUBERNETES_PROFILE);
+	}
+}


### PR DESCRIPTION
When the KUBERNETES_SERVICE_HOST environment variable is defined, the "kubernetes" profile is enabled, even if Spring cannot access the Kubernetes API.

Fixes gh-656