### PR TITLE
Allow opt-in for discovering "not-ready" service endpoints

### DIFF
--- a/docs/src/main/asciidoc/discovery-client.adoc
+++ b/docs/src/main/asciidoc/discovery-client.adoc
@@ -59,7 +59,7 @@ To discover service endpoint addresses that are not marked as "ready" by the kub
 ----
 spring.cloud.kubernetes.discovery.include-not-ready-addresses=true
 ----
-NOTE: This might be useful when discovering services for monitoring purposes, using a tool like https://codecentric.github.io/spring-boot-admin/current/[spring-boot-admin].
+NOTE: This might be useful when discovering services for monitoring purposes, and would enable inspecting the `/health` endpoint of not-ready service instances.
 ====
 
 If, for any reason, you need to disable the `DiscoveryClient`, you can set the following property in `application.properties`:

--- a/docs/src/main/asciidoc/discovery-client.adoc
+++ b/docs/src/main/asciidoc/discovery-client.adoc
@@ -52,6 +52,16 @@ spring.cloud.kubernetes.discovery.all-namespaces=true
 ----
 ====
 
+To discover service endpoint addresses that are not marked as "ready" by the kubernetes api server, you can set the following property in `application.properties` (default: false):
+
+====
+[source]
+----
+spring.cloud.kubernetes.discovery.include-not-ready-addresses=true
+----
+NOTE: This might be useful when discovering services for monitoring purposes, using a tool like https://codecentric.github.io/spring-boot-admin/current/[spring-boot-admin].
+====
+
 If, for any reason, you need to disable the `DiscoveryClient`, you can set the following property in `application.properties`:
 
 ====

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryClient.java
@@ -38,6 +38,7 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import static java.util.stream.Collectors.toMap;
@@ -150,6 +151,15 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 				}
 
 				List<EndpointAddress> addresses = s.getAddresses();
+
+				if (this.properties.isIncludeNotReadyAddresses()
+						&& !CollectionUtils.isEmpty(s.getNotReadyAddresses())) {
+					if (addresses == null) {
+						addresses = new ArrayList<EndpointAddress>();
+					}
+					addresses.addAll(s.getNotReadyAddresses());
+				}
+
 				for (EndpointAddress endpointAddress : addresses) {
 					String instanceId = null;
 					if (endpointAddress.getTargetRef() != null) {

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -44,7 +44,10 @@ public class KubernetesDiscoveryProperties {
 	/** If discovering all namespaces. */
 	private boolean allNamespaces = false;
 
-	/** If endpoint addresses not marked 'ready' by the k8s api server should be discovered */
+	/**
+	 * If endpoint addresses not marked 'ready' by the k8s api server should be
+	 * discovered.
+	 */
 	private boolean includeNotReadyAddresses = false;
 
 	/**

--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/KubernetesDiscoveryProperties.java
@@ -44,6 +44,9 @@ public class KubernetesDiscoveryProperties {
 	/** If discovering all namespaces. */
 	private boolean allNamespaces = false;
 
+	/** If endpoint addresses not marked 'ready' by the k8s api server should be discovered */
+	private boolean includeNotReadyAddresses = false;
+
 	/**
 	 * SpEL expression to filter services AFTER they have been retrieved from the
 	 * Kubernetes API server.
@@ -136,6 +139,14 @@ public class KubernetesDiscoveryProperties {
 
 	public void setAllNamespaces(boolean allNamespaces) {
 		this.allNamespaces = allNamespaces;
+	}
+
+	public boolean isIncludeNotReadyAddresses() {
+		return includeNotReadyAddresses;
+	}
+
+	public void setIncludeNotReadyAddresses(boolean includeNotReadyAddresses) {
+		this.includeNotReadyAddresses = includeNotReadyAddresses;
 	}
 
 	public int getOrder() {


### PR DESCRIPTION
Discovering "not-ready" service endpoints will help tools like Spring Boot Admin continue to monitor all endpoints, ready or not.

Should resolve https://github.com/spring-cloud/spring-cloud-kubernetes/issues/584