### PR TITLE
Update anchors for docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,8 +57,8 @@ resolves service names to Kubernetes Services.
 </dependency>
 ----
 | Load application properties from Kubernetes
-<<ConfigMap PropertySource,ConfigMaps>> and <<Secrets PropertySource,Secrets>>.
-<<PropertySource Reload,Reload>> application properties when a ConfigMap or
+<<configmap-propertysource,ConfigMaps>> and <<Secrets PropertySource,Secrets>>.
+<<propertysource-reload,Reload>> application properties when a ConfigMap or
 Secret changes.
 
 | [source,xml]

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -26,8 +26,8 @@ resolves service names to Kubernetes Services.
 </dependency>
 ----
 | Load application properties from Kubernetes
-<<ConfigMap PropertySource,ConfigMaps>> and <<Secrets PropertySource,Secrets>>.
-<<PropertySource Reload,Reload>> application properties when a ConfigMap or
+<<configmap-propertysource,ConfigMaps>> and <<Secrets PropertySource,Secrets>>.
+<<propertysource-reload,Reload>> application properties when a ConfigMap or
 Secret changes.
 
 | [source,xml]


### PR DESCRIPTION
I updated some invalid anchors in the docs and generated README.adoc via `./mvnw install -P docs`