### PR TITLE
trivial NPE when no annotations or labels to fix gh-613

### DIFF
--- a/spring-cloud-kubernetes-loadbalancer/src/main/java/org/springframework/cloud/kubernetes/loadbalancer/KubernetesServiceInstanceMapper.java
+++ b/spring-cloud-kubernetes-loadbalancer/src/main/java/org/springframework/cloud/kubernetes/loadbalancer/KubernetesServiceInstanceMapper.java
@@ -100,12 +100,13 @@ public class KubernetesServiceInstanceMapper {
 	}
 
 	private boolean isSecure(Service service, ServicePort port) {
-		final String securedLabelValue = service.getMetadata().getLabels().getOrDefault("secured", "false");
-		if (securedLabelValue.equals("true")) {
+		final ObjectMeta metadata = service.getMetadata();
+		if (metadata.getLabels() != null
+			&& metadata.getLabels().getOrDefault("secured", "false").equals("true")) {
 			return true;
 		}
-		final String securedAnnotationValue = service.getMetadata().getAnnotations().getOrDefault("secured", "false");
-		if (securedAnnotationValue.equals("true")) {
+		if (metadata.getAnnotations() != null
+			&& metadata.getAnnotations().getOrDefault("secured", "false").equals("true")) {
 			return true;
 		}
 		return (port.getName() != null && port.getName().endsWith("https"))


### PR DESCRIPTION
Add not null check to avoid null pointer exception on kubernetes objects without labels or annotations in metadata. Fixes gh-613