### PR TITLE
improvments on lazy instance

### DIFF
--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/LazilyInstantiate.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/LazilyInstantiate.java
@@ -26,27 +26,29 @@ import java.util.function.Supplier;
  */
 public final class LazilyInstantiate<T> implements Supplier<T> {
 
+	private volatile T t;
 	private final Supplier<T> supplier;
-
-	private Supplier<T> current;
 
 	private LazilyInstantiate(Supplier<T> supplier) {
 		this.supplier = supplier;
-		this.current = () -> swapper();
 	}
 
 	public static <T> LazilyInstantiate<T> using(Supplier<T> supplier) {
-		return new LazilyInstantiate<T>(supplier);
+		return new LazilyInstantiate<>(supplier);
 	}
 
-	public synchronized T get() {
-		return this.current.get();
-	}
-
-	private T swapper() {
-		T obj = this.supplier.get();
-		this.current = () -> obj;
-		return obj;
+	public T get() {
+		T localT = t;
+		if (localT == null) {
+			synchronized (this) {
+				localT = t;
+				if (localT == null) {
+					localT = supplier.get();
+					t = localT;
+				}
+			}
+		}
+		return localT;
 	}
 
 }


### PR DESCRIPTION
These are the overall changes:

 - No need for `T`, type inference will work.

 - The fact that `get` is `synchronized` implies that an instance of this class can be called concurrently, which implies that it must be safely published. But that is not the case. A correctly published instance (strictly speaking about immutable classes), must have _all_ fields final. This is required by the JLS.

Under the current implementation (I have checked `java-8` to `16`), all implementations insert proper barriers even if a _single_ field is final, i.e.:

```
     private LazilyInstantiate(Supplier<T> supplier) {
		this.supplier = supplier;
		this.current = this::swapper;
		// proper barriers are here even if current is not final
	}
```

But there are no guarantees that this will stay the same in future versions, it does not matter either: as this clearly violates the JLS.

I've tried to understand what the author wanted to do initially with this `swapper` and could not. This even looks stranger to me because the class is called: `LazilyInstantiate`, so if I pass a Supplier into a static factory method, I do not expect for that Supplier to be called _eager_, which is exactly what happens here.

	As such, my initial thought was to remove it entirely and simply have it as:

```
	public final class LazilyInstantiate<T> implements Supplier<T> {

	     private final Supplier<T> supplier;

	     private LazilyInstantiate(Supplier<T> supplier) {
		 this.supplier = supplier;
	     }

	     public static <T> LazilyInstantiate<T> using(Supplier<T> supplier) {
		 return new LazilyInstantiate<>(supplier);
	     }

	     public synchronized T get() {
		  return this.supplier.get();
	   }
    }

```

But then, this does too much. For two reasons:

- supplier is getting called all the time, even if the value was already provided by it.

- Every single call to `get` will try to acquire the lock. It is enough bad that BiasedLocking is disabled in future versions of java, but it's a lot worse under contention: pressure on each thread (even if the instance was already been provided by the supplier), pressure on GC (this is now a GC root), etc. As such I would like to use the double-check-locking idiom here, with `2` `volatile` reads and one `volatile` write, which is achieved with a local instance.