### PR TITLE
Table fix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,8 @@ Secret changes.
     <artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
 </dependency>
 ----
+| All Spring Cloud Kubernetes features.
+|===
 
 == DiscoveryClient for Kubernetes
 
@@ -1164,7 +1166,7 @@ To see the list of all Kubernetes related configuration properties please check 
 
 == Building
 
-:jdkversion: 1.7
+:jdkversion: 1.8
 
 === Basic Compile and Test
 

--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -52,3 +52,5 @@ Secret changes.
     <artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
 </dependency>
 ----
+| All Spring Cloud Kubernetes features.
+|===


### PR DESCRIPTION
The table in getting-started.adoc had no end, which put the remainder
of the document into the same table, causing numerous rendering problems.