### PR TITLE
spring-cloud-kubernetes-test-support dependency moved to Testing Dependencies section and scope test added

### DIFF
--- a/spring-cloud-kubernetes-dependencies/pom.xml
+++ b/spring-cloud-kubernetes-dependencies/pom.xml
@@ -141,12 +141,6 @@
 				<version>${project.version}</version>
 			</dependency>
 
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-kubernetes-test-support</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-
 			<!-- Own dependencies - Starters -->
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -289,6 +283,13 @@
 				<groupId>com.squareup.okhttp3</groupId>
 				<artifactId>logging-interceptor</artifactId>
 				<version>${okhttp.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-kubernetes-test-support</artifactId>
+				<version>${project.version}</version>
+				<scope>test</scope>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
org.springframework.cloud:spring-cloud-kubernetes-test-support dependency moved to Testing Dependencies section and scope test added

What about com.squareup.okhttp3 dependencies defined in Testing Dependencies section, should they have the test scope too?