### PR TITLE
Feat: Recording failure messages if actuator info failed initialization

### DIFF
--- a/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/KubernetesClientAutoConfiguration.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/KubernetesClientAutoConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesEnabled;
 import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
 import org.springframework.cloud.kubernetes.commons.KubernetesCommonsAutoConfiguration;
-import org.springframework.cloud.kubernetes.commons.PodUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -61,7 +60,7 @@ public class KubernetesClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public KubernetesClientPodUtils kubernetesPodUtils(CoreV1Api client,
-			KubernetesClientProperties kubernetesClientProperties) {
+		KubernetesClientProperties kubernetesClientProperties) {
 		return new KubernetesClientPodUtils(client, kubernetesClientProperties.getNamespace());
 	}
 
@@ -71,13 +70,13 @@ public class KubernetesClientAutoConfiguration {
 
 		@Bean
 		@ConditionalOnEnabledHealthIndicator("kubernetes")
-		public KubernetesClientHealthIndicator kubernetesHealthIndicator(PodUtils podUtils) {
+		public KubernetesClientHealthIndicator kubernetesHealthIndicator(KubernetesClientPodUtils podUtils) {
 			return new KubernetesClientHealthIndicator(podUtils);
 		}
 
 		@Bean
 		@ConditionalOnEnabledInfoContributor("kubernetes")
-		public KubernetesClientInfoContributor kubernetesInfoContributor(PodUtils podUtils) {
+		public KubernetesClientInfoContributor kubernetesInfoContributor(KubernetesClientPodUtils podUtils) {
 			return new KubernetesClientInfoContributor(podUtils);
 		}
 

--- a/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/KubernetesClientInfoContributor.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/KubernetesClientInfoContributor.java
@@ -20,9 +20,9 @@ import java.util.Collections;
 import java.util.Map;
 
 import io.kubernetes.client.openapi.models.V1Pod;
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.cloud.kubernetes.commons.AbstractKubernetesInfoContributor;
-import org.springframework.cloud.kubernetes.commons.PodUtils;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -30,9 +30,9 @@ import org.springframework.util.CollectionUtils;
  */
 public class KubernetesClientInfoContributor extends AbstractKubernetesInfoContributor {
 
-	private final PodUtils<V1Pod> utils;
+	private final KubernetesClientPodUtils utils;
 
-	public KubernetesClientInfoContributor(PodUtils<V1Pod> utils) {
+	public KubernetesClientInfoContributor(KubernetesClientPodUtils utils) {
 		this.utils = utils;
 	}
 
@@ -49,6 +49,9 @@ public class KubernetesClientInfoContributor extends AbstractKubernetesInfoContr
 			details.put(POD_IP, current.getStatus().getPodIP());
 			details.put(HOST_IP, current.getStatus().getHostIP());
 			return details;
+		}
+		if (!StringUtils.isEmpty(this.utils.getFailureMessage())) {
+			return Collections.singletonMap(INSIDE, this.utils.getFailureMessage());
 		}
 		return Collections.singletonMap(INSIDE, false);
 	}

--- a/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/KubernetesClientInfoContributorTests.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/KubernetesClientInfoContributorTests.java
@@ -18,13 +18,10 @@ package org.springframework.cloud.kubernetes.client;
 
 import java.util.Map;
 
-import io.kubernetes.client.openapi.models.V1Pod;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import org.springframework.cloud.kubernetes.commons.PodUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -49,7 +46,7 @@ import static org.springframework.cloud.kubernetes.client.StubProvider.STUB_SERV
 class KubernetesClientInfoContributorTests {
 
 	@Mock
-	private PodUtils<V1Pod> utils;
+	private KubernetesClientPodUtils utils;
 
 	@Test
 	void getDetailsIsNotInside() {


### PR DESCRIPTION
this pull helps investigating the constant failure underneath #768. if the pod-info is not successfully initialized, the exception message will be recorded instead in the actuator info endpoint