### PR TITLE
fix

### DIFF
--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigUtils.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigUtils.java
@@ -36,7 +36,7 @@ public final class Fabric8ConfigUtils {
 
 	public static String getApplicationNamespace(KubernetesClient client, String configNamespace,
 			String configurationTarget) {
-		if (StringUtils.isEmpty(configNamespace)) {
+		if (!StringUtils.hasLength(configNamespace)) {
 			LOG.debug(configurationTarget + " namespace has not been set, taking it from client (ns="
 					+ client.getNamespace() + ")");
 			configNamespace = client.getNamespace();

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigUtilsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigUtilsTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.kubernetes.fabric8.config;
 
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigUtilsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigUtilsTests.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author wind57
+ */
+public class Fabric8ConfigUtilsTests {
+
+	@ClassRule
+	public static final KubernetesServer server = new KubernetesServer();
+
+	@Test
+	public void testGetApplicationNamespaceNotPresent() {
+		String result = Fabric8ConfigUtils.getApplicationNamespace(server.getClient(), "", "target");
+		assertThat(result).isEqualTo("test");
+	}
+
+	@Test
+	public void testGetApplicationNamespacePresent() {
+		String result = Fabric8ConfigUtils.getApplicationNamespace(server.getClient(), "namespace", "target");
+		assertThat(result).isEqualTo("namespace");
+	}
+
+}


### PR DESCRIPTION
I also have a question on tests. For example `spring-cloud-kubernetes-fabric8-autoconfig` uses `junit-5`, while `spring-cloud-kubernetes-fabric8-config` where this changes happens uses `junit-4`. Is that OK? I could create a PR where `spring-cloud-kubernetes-fabric8-config` would move to `junit-5` also, for example...