### PR TITLE
Remove unnecessary API groups in sample Role

### DIFF
--- a/docs/src/main/asciidoc/security-service-accounts.adoc
+++ b/docs/src/main/asciidoc/security-service-accounts.adoc
@@ -55,7 +55,7 @@ metadata:
   namespace: YOUR-NAME-SPACE
   name: namespace-reader
 rules:
-  - apiGroups: ["", "extensions", "apps"]
+  - apiGroups: [""]
     resources: ["configmaps", "pods", "services", "endpoints", "secrets"]
     verbs: ["get", "list", "watch"]
 


### PR DESCRIPTION
- The resource requirements listed by component are all members of the
  core API group. There is no need to include the `extensions` and
  `apps` groups. This Role will currently try to grant permissions on
  types that do not exist, such a `pod.extensions` and `pod.apps`.

- If you are a member of a multitenant cluster, there's a good chance
  that you are running with either the `admin` or `edit` built-in
  Clusterroles scoped down to your namespace(s). Since certain types
  such as `pod.extensions` do not exist, your binding to a built-in Role
  will not contain permissions on these types. As such, you will get a
  permission error when trying to create the Role (trying to grant
  permissions you do not hold). The Role as written could only currently
  be created in a cluster by someone who has a higher permission level,
  such as an admin.