### PR TITLE
Kubernetes Config Fail-fast and Retry Support

### DIFF
--- a/docs/src/main/asciidoc/property-source-config.adoc
+++ b/docs/src/main/asciidoc/property-source-config.adoc
@@ -415,6 +415,11 @@ NOTE:  If you use `spring.cloud.kubernetes.config.paths` or `spring.cloud.kubern
 functionality will not work.  You will need to make a `POST` request to the `/actuator/refresh` endpoint or
 restart/redeploy the application.
 
+[#config-map-fail-fast]
+In some cases, your application may be unable to load some of your `ConfigMaps` using the Kubernetes API.
+If you want your application to fail the start-up process in such cases, you can set the
+`spring.cloud.kubernetes.config.fail-fast=true` to make the application start-up fail with an Exception.
+
 .Properties:
 [options="header,footer"]
 |===
@@ -424,6 +429,7 @@ restart/redeploy the application.
 | `spring.cloud.kubernetes.config.namespace` | `String`  | Client namespace             | Sets the Kubernetes namespace where to lookup
 | `spring.cloud.kubernetes.config.paths`     | `List`    | `null`                       | Sets the paths where `ConfigMap` instances are mounted
 | `spring.cloud.kubernetes.config.enableApi` | `Boolean` | `true`                       | Enable or disable consuming `ConfigMap` instances through APIs
+| `spring.cloud.kubernetes.config.fail-fast` | `Boolean` | `false`                      | Enable or disable failing the application start-up when an error occurred while loading a `ConfigMap`
 |===
 
 === Secrets PropertySource
@@ -578,6 +584,8 @@ the `Secret` named `s1` would be looked up in the namespace that the application
 See <<namespace-resolution,namespace-resolution>> to get a better understanding of how the namespace
 of the application is resolved.
 
+<<config-map-fail-fast,Similar to the `ConfigMaps`>>; if you want your application to fail to start 
+when it is unable to load `Secrets` property sources, you can set `spring.cloud.kubernetes.secrets.fail-fast=true`.
 
 .Properties:
 [options="header,footer"]
@@ -589,6 +597,7 @@ of the application is resolved.
 | `spring.cloud.kubernetes.secrets.labels`    | `Map`     | `null`                       | Sets the labels used to lookup secrets
 | `spring.cloud.kubernetes.secrets.paths`     | `List`    | `null`                       | Sets the paths where secrets are mounted (example 1)
 | `spring.cloud.kubernetes.secrets.enableApi` | `Boolean` | `false`                      | Enables or disables consuming secrets through APIs (examples 2 and 3)
+| `spring.cloud.kubernetes.secrets.fail-fast` | `Boolean` | `false`                      | Enable or disable failing the application start-up when an error occurred while loading a `Secret`
 |===
 
 Notes:

--- a/docs/src/main/asciidoc/property-source-config.adoc
+++ b/docs/src/main/asciidoc/property-source-config.adoc
@@ -420,16 +420,27 @@ In some cases, your application may be unable to load some of your `ConfigMaps` 
 If you want your application to fail the start-up process in such cases, you can set the
 `spring.cloud.kubernetes.config.fail-fast=true` to make the application start-up fail with an Exception.
 
+[#config-map-retry]
+You can also make your application retry loading `ConfigMap` property sources on a failure. First, you need to
+set `spring.cloud.kubernetes.config.fail-fast=true`. Then you need to add `spring-retry` 
+and `spring-boot-starter-aop` to your classpath. You can configure retry properties such as
+the maximum number of attempts, backoff options like initial interval, multiplier, max interval by setting the
+`spring.cloud.kubernetes.config.retry.*` properties.
+
 .Properties:
 [options="header,footer"]
 |===
-| Name                                       | Type      | Default                      | Description
-| `spring.cloud.kubernetes.config.enabled`   | `Boolean` | `true`                       | Enable ConfigMaps `PropertySource`
-| `spring.cloud.kubernetes.config.name`      | `String`  | `${spring.application.name}` | Sets the name of `ConfigMap` to look up
-| `spring.cloud.kubernetes.config.namespace` | `String`  | Client namespace             | Sets the Kubernetes namespace where to lookup
-| `spring.cloud.kubernetes.config.paths`     | `List`    | `null`                       | Sets the paths where `ConfigMap` instances are mounted
-| `spring.cloud.kubernetes.config.enableApi` | `Boolean` | `true`                       | Enable or disable consuming `ConfigMap` instances through APIs
-| `spring.cloud.kubernetes.config.fail-fast` | `Boolean` | `false`                      | Enable or disable failing the application start-up when an error occurred while loading a `ConfigMap`
+| Name                                                    | Type      | Default                      | Description
+| `spring.cloud.kubernetes.config.enabled`                | `Boolean` | `true`                       | Enable ConfigMaps `PropertySource`
+| `spring.cloud.kubernetes.config.name`                   | `String`  | `${spring.application.name}` | Sets the name of `ConfigMap` to look up
+| `spring.cloud.kubernetes.config.namespace`              | `String`  | Client namespace             | Sets the Kubernetes namespace where to lookup
+| `spring.cloud.kubernetes.config.paths`                  | `List`    | `null`                       | Sets the paths where `ConfigMap` instances are mounted
+| `spring.cloud.kubernetes.config.enableApi`              | `Boolean` | `true`                       | Enable or disable consuming `ConfigMap` instances through APIs
+| `spring.cloud.kubernetes.config.fail-fast`              | `Boolean` | `false`                      | Enable or disable failing the application start-up when an error occurred while loading a `ConfigMap`
+| `spring.cloud.kubernetes.config.retry.initial-interval` | `Long`    | `1000`                       | Initial retry interval in milliseconds.
+| `spring.cloud.kubernetes.config.retry.max-attempts`     | `Integer` | `6`                          | Maximum number of attempts.
+| `spring.cloud.kubernetes.config.retry.max-interval`     | `Long`    | `2000`                       | Maximum interval for backoff.
+| `spring.cloud.kubernetes.config.retry.multiplier`       | `Double`  | `1.1`                        | Multiplier for next interval.
 |===
 
 === Secrets PropertySource
@@ -587,17 +598,27 @@ of the application is resolved.
 <<config-map-fail-fast,Similar to the `ConfigMaps`>>; if you want your application to fail to start 
 when it is unable to load `Secrets` property sources, you can set `spring.cloud.kubernetes.secrets.fail-fast=true`.
 
+It is also possible to enable retry for `Secret` property sources <<config-map-retry,like the `ConfigMaps`>>.
+As with the `ConfigMap` property sources, first you need to set `spring.cloud.kubernetes.secrets.fail-fast=true`. 
+Then you need to add `spring-retry` and `spring-boot-starter-aop` to your classpath. 
+Retry behavior of the `Secret` property sources can be configured by setting `spring.cloud.kubernetes.secrets.retry.*`
+configuration properties.
+
 .Properties:
 [options="header,footer"]
 |===
-| Name                                        | Type      | Default                      | Description
-| `spring.cloud.kubernetes.secrets.enabled`   | `Boolean` | `true`                       | Enable Secrets `PropertySource`
-| `spring.cloud.kubernetes.secrets.name`      | `String`  | `${spring.application.name}` | Sets the name of the secret to look up
-| `spring.cloud.kubernetes.secrets.namespace` | `String`  | Client namespace             | Sets the Kubernetes namespace where to look up
-| `spring.cloud.kubernetes.secrets.labels`    | `Map`     | `null`                       | Sets the labels used to lookup secrets
-| `spring.cloud.kubernetes.secrets.paths`     | `List`    | `null`                       | Sets the paths where secrets are mounted (example 1)
-| `spring.cloud.kubernetes.secrets.enableApi` | `Boolean` | `false`                      | Enables or disables consuming secrets through APIs (examples 2 and 3)
-| `spring.cloud.kubernetes.secrets.fail-fast` | `Boolean` | `false`                      | Enable or disable failing the application start-up when an error occurred while loading a `Secret`
+| Name                                                     | Type      | Default                      | Description
+| `spring.cloud.kubernetes.secrets.enabled`                | `Boolean` | `true`                       | Enable Secrets `PropertySource`
+| `spring.cloud.kubernetes.secrets.name`                   | `String`  | `${spring.application.name}` | Sets the name of the secret to look up
+| `spring.cloud.kubernetes.secrets.namespace`              | `String`  | Client namespace             | Sets the Kubernetes namespace where to look up
+| `spring.cloud.kubernetes.secrets.labels`                 | `Map`     | `null`                       | Sets the labels used to lookup secrets
+| `spring.cloud.kubernetes.secrets.paths`                  | `List`    | `null`                       | Sets the paths where secrets are mounted (example 1)
+| `spring.cloud.kubernetes.secrets.enableApi`              | `Boolean` | `false`                      | Enables or disables consuming secrets through APIs (examples 2 and 3)
+| `spring.cloud.kubernetes.secrets.fail-fast`              | `Boolean` | `false`                      | Enable or disable failing the application start-up when an error occurred while loading a `Secret`
+| `spring.cloud.kubernetes.secrets.retry.initial-interval` | `Long`    | `1000`                       | Initial retry interval in milliseconds.
+| `spring.cloud.kubernetes.secrets.retry.max-attempts`     | `Integer` | `6`                          | Maximum number of attempts.
+| `spring.cloud.kubernetes.secrets.retry.max-interval`     | `Long`    | `2000`                       | Maximum interval for backoff.
+| `spring.cloud.kubernetes.secrets.retry.multiplier`       | `Double`  | `1.1`                        | Multiplier for next interval.
 |===
 
 Notes:

--- a/spring-cloud-kubernetes-client-config/pom.xml
+++ b/spring-cloud-kubernetes-client-config/pom.xml
@@ -86,6 +86,21 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 

--- a/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,19 +34,21 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Ryan Baxter
+ * @author Isik Erhan
  */
 public class KubernetesClientConfigMapPropertySource extends ConfigMapPropertySource {
 
 	private static final Log LOG = LogFactory.getLog(KubernetesClientConfigMapPropertySource.class);
 
 	public KubernetesClientConfigMapPropertySource(CoreV1Api coreV1Api, String name, String namespace,
-			Environment environment, String prefix) {
-		super(getName(name, namespace), getData(coreV1Api, name, namespace, environment, prefix));
+			Environment environment, String prefix, boolean failFast) {
+		super(getName(name, namespace), getData(coreV1Api, name, namespace, environment, prefix, failFast));
 	}
 
 	private static Map<String, Object> getData(CoreV1Api coreV1Api, String name, String namespace,
-			Environment environment, String prefix) {
+			Environment environment, String prefix, boolean failFast) {
 
+		LOG.info("Loading ConfigMap with name '" + name + "' in namespace '" + namespace + "'");
 		try {
 			Set<String> names = new HashSet<>();
 			names.add(name);
@@ -70,6 +72,11 @@ public class KubernetesClientConfigMapPropertySource extends ConfigMapPropertySo
 			return result;
 		}
 		catch (ApiException e) {
+			if (failFast) {
+				throw new IllegalStateException(
+						"Unable to read ConfigMap with name '" + name + "' in namespace '" + namespace + "'", e);
+			}
+
 			LOG.warn("Unable to get ConfigMap " + name + " in namespace " + namespace, e);
 		}
 		return Collections.emptyMap();

--- a/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySourceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * @author Ryan Baxter
+ * @author Isik Erhan
  */
 public class KubernetesClientConfigMapPropertySourceLocator extends ConfigMapPropertySourceLocator {
 
@@ -88,7 +89,7 @@ public class KubernetesClientConfigMapPropertySourceLocator extends ConfigMapPro
 		}
 
 		return new KubernetesClientConfigMapPropertySource(coreV1Api, name, namespace, environment,
-				normalizedSource.getPrefix());
+				normalizedSource.getPrefix(), this.properties.isFailFast());
 	}
 
 }

--- a/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientSecretsPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientSecretsPropertySourceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import static org.springframework.cloud.kubernetes.commons.config.ConfigUtils.ge
 
 /**
  * @author Ryan Baxter
+ * @author Isik Erhan
  */
 public class KubernetesClientSecretsPropertySourceLocator extends SecretsPropertySourceLocator {
 
@@ -90,7 +91,7 @@ public class KubernetesClientSecretsPropertySourceLocator extends SecretsPropert
 		}
 
 		return new KubernetesClientSecretsPropertySource(coreV1Api, secretName, namespace, environment,
-				normalizedSource.getLabels());
+				normalizedSource.getLabels(), this.properties.isFailFast());
 	}
 
 }

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySourceLocatorRetryTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySourceLocatorRetryTests.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kubernetes.client.openapi.JSON;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ConfigMapList;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1SecretList;
+import io.kubernetes.client.util.ClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Isik Erhan
+ */
+public class KubernetesClientConfigMapPropertySourceLocatorRetryTests {
+
+	private static final String API = "/api/v1/namespaces/default/configmaps";
+
+	private static final String SECRETS_API = "/api/v1/namespaces/default/secrets";
+
+	private static WireMockServer wireMockServer;
+
+	private static MockedStatic<KubernetesClientUtils> clientUtilsMock;
+
+	@BeforeAll
+	public static void setup() {
+		wireMockServer = new WireMockServer(options().dynamicPort());
+		wireMockServer.start();
+		WireMock.configureFor(wireMockServer.port());
+
+		clientUtilsMock = mockStatic(KubernetesClientUtils.class);
+		clientUtilsMock.when(KubernetesClientUtils::kubernetesApiClient)
+				.thenReturn(new ClientBuilder().setBasePath(wireMockServer.baseUrl()).build());
+		stubConfigMapAndSecretsDefaults();
+	}
+
+	private static void stubConfigMapAndSecretsDefaults() {
+		// return empty config map / secret list to not fail context creation
+		stubFor(get(API).willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(new V1ConfigMapList()))));
+		stubFor(get(SECRETS_API)
+				.willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(new V1SecretList()))));
+	}
+
+	@AfterAll
+	public static void teardown() {
+		wireMockServer.stop();
+		clientUtilsMock.close();
+	}
+
+	@AfterEach
+	public void afterEach() {
+		WireMock.reset();
+		stubConfigMapAndSecretsDefaults();
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default",
+					"spring.cloud.kubernetes.config.fail-fast=true",
+					"spring.cloud.kubernetes.config.retry.max-attempts=5" },
+			classes = App.class)
+	class ConfigMapRetryEnabled {
+
+		@SpyBean
+		private KubernetesClientConfigMapPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetryWhenThereIsNoFailure() {
+
+			Map<String, String> data = new HashMap<>();
+			data.put("some.prop", "theValue");
+			data.put("some.number", "0");
+
+			V1ConfigMapList configMapList = new V1ConfigMapList()
+					.addItemsItem(new V1ConfigMap().metadata(new V1ObjectMeta().name("application")).data(data));
+
+			stubFor(get(API).willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(configMapList))));
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.prop")).isEqualTo("theValue");
+			assertThat(propertySource.getProperty("some.number")).isEqualTo("0");
+		}
+
+		@Test
+		public void locateShouldRetryAndRecover() {
+			Map<String, String> data = new HashMap<>();
+			data.put("some.prop", "theValue");
+			data.put("some.number", "0");
+
+			V1ConfigMapList configMapList = new V1ConfigMapList()
+					.addItemsItem(new V1ConfigMap().metadata(new V1ObjectMeta().name("application")).data(data));
+
+			// fail 3 times
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs(STARTED)
+					.willReturn(aResponse().withStatus(500)).willSetStateTo("Failed once"));
+
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs("Failed once")
+					.willReturn(aResponse().withStatus(500)).willSetStateTo("Failed twice"));
+
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs("Failed twice")
+					.willReturn(aResponse().withStatus(500)).willSetStateTo("Failed thrice"));
+
+			// then succeed
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs("Failed thrice")
+					.willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(configMapList))));
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify retried 4 times
+			verify(propertySourceLocator, times(4)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.prop")).isEqualTo("theValue");
+			assertThat(propertySource.getProperty("some.number")).isEqualTo("0");
+		}
+
+		@Test
+		public void locateShouldRetryAndFail() {
+			// fail all the 5 requests
+			stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+			assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessage("Unable to read ConfigMap with name 'application' in namespace 'default'");
+
+			// verify retried 5 times until failure
+			verify(propertySourceLocator, times(5)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default" }, classes = App.class)
+	class ConfigMapRetryDisabled {
+
+		@SpyBean
+		private KubernetesClientConfigMapPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetry() {
+
+			stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+			"spring.cloud.kubernetes.client.namespace=default", "spring.cloud.kubernetes.secrets.fail-fast=true" },
+			classes = App.class)
+	class ConfigMapRetryDisabledButSecretsRetryEnabled {
+
+		@SpyBean
+		private KubernetesClientConfigMapPropertySourceLocator propertySourceLocator;
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Test
+		public void locateShouldNotRetry() {
+
+			/*
+			 * Enabling secrets fail-fast causes Spring Retry to be enabled and a
+			 * RetryOperationsInterceptor bean with NeverRetryPolicy for config maps to be
+			 * defined. ConfigMapPropertySourceLocator should not retry even Spring Retry
+			 * is enabled.
+			 */
+
+			stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+			assertThat(context.containsBean("configMapPropertiesRetryInterceptor")).isTrue();
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify that propertySourceLocator.locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+	@SpringBootApplication
+	static class App {
+
+	}
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySourceLocatorTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapPropertySourceLocatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,10 +46,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Ryan Baxter
+ * @author Isik Erhan
  */
 class KubernetesClientConfigMapPropertySourceLocatorTests {
 
@@ -166,6 +168,39 @@ class KubernetesClientConfigMapPropertySourceLocatorTests {
 		assertThatThrownBy(() -> new KubernetesClientConfigMapPropertySourceLocator(api, configMapConfigProperties,
 				new KubernetesNamespaceProvider(new MockEnvironment())).locate(new MockEnvironment()))
 						.isInstanceOf(NamespaceResolutionFailedException.class);
+	}
+
+	@Test
+	public void locateShouldThrowExceptionOnFailureWhenFailFastIsEnabled() {
+		CoreV1Api api = new CoreV1Api();
+		stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+		ConfigMapConfigProperties configMapConfigProperties = new ConfigMapConfigProperties();
+		configMapConfigProperties.setName("bootstrap-640");
+		configMapConfigProperties.setNamespace("default");
+		configMapConfigProperties.setFailFast(true);
+
+		KubernetesClientConfigMapPropertySourceLocator locator = new KubernetesClientConfigMapPropertySourceLocator(api,
+				configMapConfigProperties, new KubernetesNamespaceProvider(new MockEnvironment()));
+
+		assertThatThrownBy(() -> locator.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Unable to read ConfigMap with name 'bootstrap-640' in namespace 'default'");
+	}
+
+	@Test
+	public void locateShouldNotThrowExceptionOnFailureWhenFailFastIsDisabled() {
+		CoreV1Api api = new CoreV1Api();
+		stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+		ConfigMapConfigProperties configMapConfigProperties = new ConfigMapConfigProperties();
+		configMapConfigProperties.setName("bootstrap-640");
+		configMapConfigProperties.setNamespace("default");
+		configMapConfigProperties.setFailFast(false);
+
+		KubernetesClientConfigMapPropertySourceLocator locator = new KubernetesClientConfigMapPropertySourceLocator(api,
+				configMapConfigProperties, new KubernetesNamespaceProvider(new MockEnvironment()));
+
+		assertThatNoException().isThrownBy(() -> locator.locate(new MockEnvironment()));
 	}
 
 }

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientSecretsPropertySourceLocatorRetryTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientSecretsPropertySourceLocatorRetryTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kubernetes.client.openapi.JSON;
+import io.kubernetes.client.openapi.models.V1ConfigMapList;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Secret;
+import io.kubernetes.client.openapi.models.V1SecretList;
+import io.kubernetes.client.util.ClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Isik Erhan
+ */
+public class KubernetesClientSecretsPropertySourceLocatorRetryTests {
+
+	private static final String API = "/api/v1/namespaces/default/secrets";
+
+	private static final String CONFIG_MAPS_API = "/api/v1/namespaces/default/configmaps";
+
+	private static WireMockServer wireMockServer;
+
+	private static MockedStatic<KubernetesClientUtils> clientUtilsMock;
+
+	@BeforeAll
+	public static void setup() {
+		wireMockServer = new WireMockServer(options().dynamicPort());
+		wireMockServer.start();
+		WireMock.configureFor(wireMockServer.port());
+
+		clientUtilsMock = mockStatic(KubernetesClientUtils.class);
+		clientUtilsMock.when(KubernetesClientUtils::kubernetesApiClient)
+				.thenReturn(new ClientBuilder().setBasePath(wireMockServer.baseUrl()).build());
+		stubConfigMapAndSecretsDefaults();
+	}
+
+	private static void stubConfigMapAndSecretsDefaults() {
+		// return empty config map / secret list to not fail context creation
+		stubFor(get(API).willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(new V1SecretList()))));
+		stubFor(get(CONFIG_MAPS_API)
+				.willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(new V1ConfigMapList()))));
+	}
+
+	@AfterAll
+	public static void teardown() {
+		wireMockServer.stop();
+		clientUtilsMock.close();
+	}
+
+	@AfterEach
+	public void afterEach() {
+		WireMock.reset();
+		stubConfigMapAndSecretsDefaults();
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+			"spring.cloud.kubernetes.client.namespace=default", "spring.cloud.kubernetes.secrets.fail-fast=true",
+			"spring.cloud.kubernetes.secrets.retry.max-attempts=5", "spring.cloud.kubernetes.secrets.name=my-secret",
+			"spring.cloud.kubernetes.secrets.enable-api=true" }, classes = App.class)
+	class SecretsRetryEnabled {
+
+		@SpyBean
+		private KubernetesClientSecretsPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetryWhenThereIsNoFailure() {
+
+			Map<String, byte[]> data = new HashMap<>();
+			data.put("some.sensitive.prop", "theSensitiveValue".getBytes());
+			data.put("some.sensitive.number", "1".getBytes());
+
+			V1SecretList secretList = new V1SecretList()
+					.addItemsItem(new V1Secret().metadata(new V1ObjectMeta().name("my-secret")).data(data));
+
+			stubFor(get(API).willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(secretList))));
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.sensitive.prop")).isEqualTo("theSensitiveValue");
+			assertThat(propertySource.getProperty("some.sensitive.number")).isEqualTo("1");
+		}
+
+		@Test
+		public void locateShouldRetryAndRecover() {
+			Map<String, byte[]> data = new HashMap<>();
+			data.put("some.sensitive.prop", "theSensitiveValue".getBytes());
+			data.put("some.sensitive.number", "1".getBytes());
+
+			V1SecretList secretList = new V1SecretList()
+					.addItemsItem(new V1Secret().metadata(new V1ObjectMeta().name("my-secret")).data(data));
+
+			// fail 3 times
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs(STARTED)
+					.willReturn(aResponse().withStatus(500)).willSetStateTo("Failed once"));
+
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs("Failed once")
+					.willReturn(aResponse().withStatus(500)).willSetStateTo("Failed twice"));
+
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs("Failed twice")
+					.willReturn(aResponse().withStatus(500)).willSetStateTo("Failed thrice"));
+
+			// then succeed
+			stubFor(get(API).inScenario("Retry and Recover").whenScenarioStateIs("Failed thrice")
+					.willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(secretList))));
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify retried 4 times
+			verify(propertySourceLocator, times(4)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.sensitive.prop")).isEqualTo("theSensitiveValue");
+			assertThat(propertySource.getProperty("some.sensitive.number")).isEqualTo("1");
+		}
+
+		@Test
+		public void locateShouldRetryAndFail() {
+			// fail all the 5 requests
+			stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+			assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessage("Unable to read Secret with name 'my-secret' or labels [{}] in namespace 'default'");
+
+			// verify retried 5 times until failure
+			verify(propertySourceLocator, times(5)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default",
+					"spring.cloud.kubernetes.secrets.name=my-secret",
+					"spring.cloud.kubernetes.secrets.enable-api=true" },
+			classes = App.class)
+	class SecretsRetryDisabled {
+
+		@SpyBean
+		private KubernetesClientSecretsPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetry() {
+
+			stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default",
+					"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.secrets.name=my-secret",
+					"spring.cloud.kubernetes.secrets.enable-api=true" },
+			classes = App.class)
+	class SecretsRetryDisabledButConfigMapRetryEnabled {
+
+		@SpyBean
+		private KubernetesClientSecretsPropertySourceLocator propertySourceLocator;
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Test
+		public void locateShouldNotRetry() {
+
+			/*
+			 * Enabling config map fail-fast causes Spring Retry to be enabled and a
+			 * RetryOperationsInterceptor bean with NeverRetryPolicy for secrets to be
+			 * defined. SecretsPropertySourceLocator should not retry even Spring Retry is
+			 * enabled.
+			 */
+
+			stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
+
+			assertThat(context.containsBean("secretsPropertiesRetryInterceptor")).isTrue();
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify that propertySourceLocator.locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+	@SpringBootApplication
+	static class App {
+
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/pom.xml
+++ b/spring-cloud-kubernetes-commons/pom.xml
@@ -52,6 +52,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
 		</dependency>
+        <dependency>
+                <groupId>org.springframework.retry</groupId>
+                <artifactId>spring-retry</artifactId>
+                <optional>true</optional>
+        </dependency>
+        <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-aop</artifactId>
+                <optional>true</optional>
+        </dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/AbstractConfigProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/AbstractConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.springframework.cloud.kubernetes.commons.config;
  * Abstraction over configuration properties.
  *
  * @author Ioannis Canellos
+ * @author Isik Erhan
  */
 public abstract class AbstractConfigProperties {
 
@@ -30,6 +31,8 @@ public abstract class AbstractConfigProperties {
 	protected String namespace;
 
 	protected boolean useNameAsPrefix;
+
+	protected boolean failFast = false;
 
 	public abstract String getConfigurationTarget();
 
@@ -63,6 +66,14 @@ public abstract class AbstractConfigProperties {
 
 	public void setUseNameAsPrefix(boolean useNameAsPrefix) {
 		this.useNameAsPrefix = useNameAsPrefix;
+	}
+
+	public boolean isFailFast() {
+		return failFast;
+	}
+
+	public void setFailFast(boolean failFast) {
+		this.failFast = failFast;
 	}
 
 }

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/AbstractConfigProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/AbstractConfigProperties.java
@@ -34,6 +34,8 @@ public abstract class AbstractConfigProperties {
 
 	protected boolean failFast = false;
 
+	protected RetryProperties retry = new RetryProperties();
+
 	public abstract String getConfigurationTarget();
 
 	public boolean isEnabled() {
@@ -74,6 +76,73 @@ public abstract class AbstractConfigProperties {
 
 	public void setFailFast(boolean failFast) {
 		this.failFast = failFast;
+	}
+
+	public RetryProperties getRetry() {
+		return retry;
+	}
+
+	public void setRetry(RetryProperties retry) {
+		this.retry = retry;
+	}
+
+	/**
+	 * Kubernetes config retry properties.
+	 */
+	public static class RetryProperties {
+
+		/**
+		 * Initial retry interval in milliseconds.
+		 */
+		private long initialInterval = 1000;
+
+		/**
+		 * Multiplier for next interval.
+		 */
+		private double multiplier = 1.1;
+
+		/**
+		 * Maximum interval for backoff.
+		 */
+		private long maxInterval = 2000;
+
+		/**
+		 * Maximum number of attempts.
+		 */
+		private int maxAttempts = 6;
+
+		public long getInitialInterval() {
+			return this.initialInterval;
+		}
+
+		public void setInitialInterval(long initialInterval) {
+			this.initialInterval = initialInterval;
+		}
+
+		public double getMultiplier() {
+			return this.multiplier;
+		}
+
+		public void setMultiplier(double multiplier) {
+			this.multiplier = multiplier;
+		}
+
+		public long getMaxInterval() {
+			return this.maxInterval;
+		}
+
+		public void setMaxInterval(long maxInterval) {
+			this.maxInterval = maxInterval;
+		}
+
+		public int getMaxAttempts() {
+			return this.maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
+		}
+
 	}
 
 }

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnConfigMapPropertiesRetryDisabled.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnConfigMapPropertiesRetryDisabled.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that matches when at least one of Spring Cloud
+ * Kubernetes, Kubernetes ConfigMap property sources or Kubernetes ConfigMap property
+ * sources fail fast (thus retry) is disabled.
+ *
+ * @author Isik Erhan
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Conditional(ConditionalOnConfigMapPropertiesRetryDisabled.OnConfigMapPropertiesRetryDisabled.class)
+public @interface ConditionalOnConfigMapPropertiesRetryDisabled {
+
+	class OnConfigMapPropertiesRetryDisabled extends NoneNestedConditions {
+
+		OnConfigMapPropertiesRetryDisabled() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnConfigMapPropertiesRetryEnabled
+		static class OnConfigMapPropertiesRetryEnabled {
+
+		}
+
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnConfigMapPropertiesRetryEnabled.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnConfigMapPropertiesRetryEnabled.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesConfigEnabled;
+import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesEnabled;
+
+/**
+ * {@link org.springframework.context.annotation.Conditional @Conditional} that only
+ * matches when Spring Cloud Kubernetes, Kubernetes ConfigMap property sources and
+ * Kubernetes ConfigMap property sources fail fast (thus retry) are enabled.
+ *
+ * @author Isik Erhan
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnKubernetesEnabled
+@ConditionalOnKubernetesConfigEnabled
+@ConditionalOnProperty(prefix = ConfigMapConfigProperties.PREFIX, name = "fail-fast", havingValue = "true")
+public @interface ConditionalOnConfigMapPropertiesRetryEnabled {
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnKubernetesConfigPropertiesRetryEnabled.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnKubernetesConfigPropertiesRetryEnabled.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that matches when either or both of
+ * {@link ConditionalOnConfigMapPropertiesRetryEnabled @ConditionalOnConfigMapPropertiesRetryEnabled}
+ * and
+ * {@link ConditionalOnSecretsPropertiesRetryEnabled @ConditionalOnSecretsPropertiesRetryEnabled}.
+ *
+ * @author Isik Erhan
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Conditional(ConditionalOnKubernetesConfigPropertiesRetryEnabled.OnKubernetesConfigPropertiesRetryEnabled.class)
+public @interface ConditionalOnKubernetesConfigPropertiesRetryEnabled {
+
+	class OnKubernetesConfigPropertiesRetryEnabled extends AnyNestedCondition {
+
+		OnKubernetesConfigPropertiesRetryEnabled() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnConfigMapPropertiesRetryEnabled
+		static class OnConfigMapPropertiesRetryEnabled {
+
+		}
+
+		@ConditionalOnSecretsPropertiesRetryEnabled
+		static class OnSecretsPropertiesRetryEnabled {
+
+		}
+
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnSecretsPropertiesRetryDisabled.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnSecretsPropertiesRetryDisabled.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.context.annotation.Conditional;
+
+/**
+ * {@link Conditional @Conditional} that matches when at least one of Spring Cloud
+ * Kubernetes, Kubernetes Secret property sources or Kubernetes Secret property sources
+ * fail fast (thus retry) is disabled.
+ *
+ * @author Isik Erhan
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Conditional(ConditionalOnSecretsPropertiesRetryDisabled.OnSecretsPropertiesRetryDisabled.class)
+public @interface ConditionalOnSecretsPropertiesRetryDisabled {
+
+	class OnSecretsPropertiesRetryDisabled extends NoneNestedConditions {
+
+		OnSecretsPropertiesRetryDisabled() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnSecretsPropertiesRetryEnabled
+		static class OnSecretsPropertiesRetryEnabled {
+
+		}
+
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnSecretsPropertiesRetryEnabled.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConditionalOnSecretsPropertiesRetryEnabled.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesEnabled;
+import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesSecretsEnabled;
+
+/**
+ * {@link org.springframework.context.annotation.Conditional @Conditional} that only
+ * matches when Spring Cloud Kubernetes, Kubernetes Secret property sources and Kubernetes
+ * Secret property sources fail fast (thus retry) are enabled.
+ *
+ * @author Isik Erhan
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnKubernetesEnabled
+@ConditionalOnKubernetesSecretsEnabled
+@ConditionalOnProperty(prefix = SecretsConfigProperties.PREFIX, name = "fail-fast", havingValue = "true")
+public @interface ConditionalOnSecretsPropertiesRetryEnabled {
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigMapConfigProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigMapConfigProperties.java
@@ -31,9 +31,15 @@ import org.springframework.util.StringUtils;
  * Config map configuration properties.
  *
  * @author Ioannis Canellos
+ * @author Isik Erhan
  */
-@ConfigurationProperties("spring.cloud.kubernetes.config")
+@ConfigurationProperties(ConfigMapConfigProperties.PREFIX)
 public class ConfigMapConfigProperties extends AbstractConfigProperties {
+
+	/**
+	 * Prefix for Kubernetes secrets configuration properties.
+	 */
+	public static final String PREFIX = "spring.cloud.kubernetes.config";
 
 	private static final Log LOG = LogFactory.getLog(ConfigMapConfigProperties.class);
 

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigMapPropertySourceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.kubernetes.commons.config;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -36,6 +37,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
+import org.springframework.retry.annotation.Retryable;
 
 import static org.springframework.cloud.kubernetes.commons.config.ConfigUtils.getApplicationName;
 import static org.springframework.cloud.kubernetes.commons.config.PropertySourceUtils.KEY_VALUE_TO_PROPERTIES;
@@ -47,6 +49,7 @@ import static org.springframework.cloud.kubernetes.commons.config.PropertySource
  *
  * @author Ioannis Canellos
  * @author Michael Moudatsos
+ * @author Isik Erhan
  */
 public abstract class ConfigMapPropertySourceLocator implements PropertySourceLocator {
 
@@ -62,6 +65,7 @@ public abstract class ConfigMapPropertySourceLocator implements PropertySourceLo
 			String configurationTarget, ConfigurableEnvironment environment);
 
 	@Override
+	@Retryable(interceptor = "configMapPropertiesRetryInterceptor")
 	public PropertySource<?> locate(Environment environment) {
 		if (environment instanceof ConfigurableEnvironment) {
 			ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
@@ -78,6 +82,12 @@ public abstract class ConfigMapPropertySourceLocator implements PropertySourceLo
 			return composite;
 		}
 		return null;
+	}
+
+	@Override
+	@Retryable(interceptor = "configMapPropertiesRetryInterceptor")
+	public Collection<PropertySource<?>> locateCollection(Environment environment) {
+		return PropertySourceLocator.super.locateCollection(environment);
 	}
 
 	private MapPropertySource getMapPropertySourceForSingleConfigMap(ConfigurableEnvironment environment,

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesBootstrapConfiguration.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,69 @@
 
 package org.springframework.cloud.kubernetes.commons.config;
 
+import org.aspectj.lang.annotation.Aspect;
+
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesEnabled;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.interceptor.RetryInterceptorBuilder;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+import org.springframework.retry.policy.NeverRetryPolicy;
 
 /**
  * @author Ryan Baxter
+ * @author Isik Erhan
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnKubernetesEnabled
 @EnableConfigurationProperties({ ConfigMapConfigProperties.class, SecretsConfigProperties.class })
 public class KubernetesBootstrapConfiguration {
+
+	@ConditionalOnKubernetesConfigPropertiesRetryEnabled
+	@ConditionalOnClass({ Retryable.class, Aspect.class, AopAutoConfiguration.class })
+	@Configuration(proxyBeanMethods = false)
+	@EnableRetry(proxyTargetClass = true)
+	@Import(AopAutoConfiguration.class)
+	static class RetryConfiguration {
+
+		private static RetryOperationsInterceptor retryOperationsInterceptor(
+				AbstractConfigProperties.RetryProperties retryProperties) {
+			return RetryInterceptorBuilder.stateless().backOffOptions(retryProperties.getInitialInterval(),
+					retryProperties.getMultiplier(), retryProperties.getMaxInterval())
+					.maxAttempts(retryProperties.getMaxAttempts()).build();
+		}
+
+		@Bean
+		@ConditionalOnConfigMapPropertiesRetryEnabled
+		public RetryOperationsInterceptor configMapPropertiesRetryInterceptor(
+				ConfigMapConfigProperties configProperties) {
+			return retryOperationsInterceptor(configProperties.getRetry());
+		}
+
+		@Bean("configMapPropertiesRetryInterceptor")
+		@ConditionalOnConfigMapPropertiesRetryDisabled
+		public RetryOperationsInterceptor configMapPropertiesRetryInterceptorNoRetry() {
+			return RetryInterceptorBuilder.stateless().retryPolicy(new NeverRetryPolicy()).build();
+		}
+
+		@Bean
+		@ConditionalOnSecretsPropertiesRetryEnabled
+		public RetryOperationsInterceptor secretsPropertiesRetryInterceptor(SecretsConfigProperties configProperties) {
+			return retryOperationsInterceptor(configProperties.getRetry());
+		}
+
+		@Bean("secretsPropertiesRetryInterceptor")
+		@ConditionalOnSecretsPropertiesRetryDisabled
+		public RetryOperationsInterceptor secretsPropertiesRetryInterceptorNoRetry() {
+			return RetryInterceptorBuilder.stateless().retryPolicy(new NeverRetryPolicy()).build();
+		}
+
+	}
 
 }

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/SecretsConfigProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/SecretsConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,15 @@ import org.springframework.util.StringUtils;
  *
  * @author l burgazzoli
  * @author Haytham Mohamed
+ * @author Isik Erhan
  */
-@ConfigurationProperties("spring.cloud.kubernetes.secrets")
+@ConfigurationProperties(SecretsConfigProperties.PREFIX)
 public class SecretsConfigProperties extends AbstractConfigProperties {
+
+	/**
+	 * Prefix for Kubernetes secrets configuration properties.
+	 */
+	public static final String PREFIX = "spring.cloud.kubernetes.secrets";
 
 	private boolean enableApi = false;
 

--- a/spring-cloud-kubernetes-commons/src/test/java/org/springframework/cloud/kubernetes/commons/config/KubernetesBootstrapConfigurationTests.java
+++ b/spring-cloud-kubernetes-commons/src/test/java/org/springframework/cloud/kubernetes/commons/config/KubernetesBootstrapConfigurationTests.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.util.Map;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.kubernetes.commons.config.AbstractConfigProperties.RetryProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Isik Erhan
+ */
+public class KubernetesBootstrapConfigurationTests {
+
+	@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = App.class)
+	@Nested
+	public class FailFastDisabled {
+
+		@Autowired
+		ConfigurableApplicationContext context;
+
+		@Test
+		public void shouldNotDefineRetryBeans() {
+			assertThat(context.getBeansOfType(RetryOperationsInterceptor.class)).isEmpty();
+		}
+
+	}
+
+	@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = App.class,
+			properties = { "spring.cloud.kubernetes.config.fail-fast=true" })
+	@Nested
+	public class ConfigMapFailFastEnabled {
+
+		@Autowired
+		ConfigurableApplicationContext context;
+
+		@Autowired
+		ConfigMapConfigProperties configMapConfigProperties;
+
+		@Test
+		public void shouldDefineRequiredBeans() {
+			Map<String, RetryOperationsInterceptor> retryInterceptors = context
+					.getBeansOfType(RetryOperationsInterceptor.class);
+			assertThat(retryInterceptors.containsKey("configMapPropertiesRetryInterceptor")).isTrue();
+			assertThat(retryInterceptors.containsKey("secretsPropertiesRetryInterceptor")).isTrue();
+		}
+
+		@Test
+		public void retryConfigurationShouldBeDefault() {
+			RetryProperties retryProperties = configMapConfigProperties.getRetry();
+			RetryProperties defaultRetryProperties = new RetryProperties();
+
+			assertThat(retryProperties.getMaxAttempts()).isEqualTo(defaultRetryProperties.getMaxAttempts());
+			assertThat(retryProperties.getInitialInterval()).isEqualTo(defaultRetryProperties.getInitialInterval());
+			assertThat(retryProperties.getMaxInterval()).isEqualTo(defaultRetryProperties.getMaxInterval());
+			assertThat(retryProperties.getMultiplier()).isEqualTo(defaultRetryProperties.getMultiplier());
+		}
+
+	}
+
+	@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = App.class,
+			properties = { "spring.cloud.kubernetes.secrets.fail-fast=true" })
+	@Nested
+	public class SecretsFailFastEnabled {
+
+		@Autowired
+		ConfigurableApplicationContext context;
+
+		@Autowired
+		SecretsConfigProperties secretsConfigProperties;
+
+		@Test
+		public void shouldDefineRequiredBeans() {
+			Map<String, RetryOperationsInterceptor> retryInterceptors = context
+					.getBeansOfType(RetryOperationsInterceptor.class);
+			assertThat(retryInterceptors.containsKey("configMapPropertiesRetryInterceptor")).isTrue();
+			assertThat(retryInterceptors.containsKey("secretsPropertiesRetryInterceptor")).isTrue();
+		}
+
+		@Test
+		public void retryConfigurationShouldBeDefault() {
+			RetryProperties retryProperties = secretsConfigProperties.getRetry();
+			RetryProperties defaultRetryProperties = new RetryProperties();
+
+			assertThat(retryProperties.getMaxAttempts()).isEqualTo(defaultRetryProperties.getMaxAttempts());
+			assertThat(retryProperties.getInitialInterval()).isEqualTo(defaultRetryProperties.getInitialInterval());
+			assertThat(retryProperties.getMaxInterval()).isEqualTo(defaultRetryProperties.getMaxInterval());
+			assertThat(retryProperties.getMultiplier()).isEqualTo(defaultRetryProperties.getMultiplier());
+		}
+
+	}
+
+	@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = App.class, properties = {
+			"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.secrets.fail-fast=true" })
+	@Nested
+	public class ConfigMapAndSecretsFailFastEnabledWithDefaultRetryConfiguration {
+
+		@Autowired
+		ConfigurableApplicationContext context;
+
+		@Autowired
+		ConfigMapConfigProperties configMapConfigProperties;
+
+		@Autowired
+		SecretsConfigProperties secretsConfigProperties;
+
+		@Test
+		public void shouldDefineRequiredBeans() {
+			Map<String, RetryOperationsInterceptor> retryInterceptors = context
+					.getBeansOfType(RetryOperationsInterceptor.class);
+			assertThat(retryInterceptors.containsKey("configMapPropertiesRetryInterceptor")).isTrue();
+			assertThat(retryInterceptors.containsKey("secretsPropertiesRetryInterceptor")).isTrue();
+		}
+
+		@Test
+		public void retryConfigurationShouldBeDefault() {
+			RetryProperties defaultRetryProperties = new RetryProperties();
+
+			RetryProperties configMapRetryProperties = configMapConfigProperties.getRetry();
+
+			assertThat(configMapRetryProperties.getMaxAttempts()).isEqualTo(defaultRetryProperties.getMaxAttempts());
+			assertThat(configMapRetryProperties.getInitialInterval())
+					.isEqualTo(defaultRetryProperties.getInitialInterval());
+			assertThat(configMapRetryProperties.getMaxInterval()).isEqualTo(defaultRetryProperties.getMaxInterval());
+			assertThat(configMapRetryProperties.getMultiplier()).isEqualTo(defaultRetryProperties.getMultiplier());
+
+			RetryProperties secretsRetryProperties = secretsConfigProperties.getRetry();
+
+			assertThat(secretsRetryProperties.getMaxAttempts()).isEqualTo(defaultRetryProperties.getMaxAttempts());
+			assertThat(secretsRetryProperties.getInitialInterval())
+					.isEqualTo(defaultRetryProperties.getInitialInterval());
+			assertThat(secretsRetryProperties.getMaxInterval()).isEqualTo(defaultRetryProperties.getMaxInterval());
+			assertThat(secretsRetryProperties.getMultiplier()).isEqualTo(defaultRetryProperties.getMultiplier());
+		}
+
+	}
+
+	@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = App.class,
+			properties = { "spring.cloud.kubernetes.config.fail-fast=true",
+					"spring.cloud.kubernetes.config.retry.max-attempts=3",
+					"spring.cloud.kubernetes.config.retry.initial-interval=1500",
+					"spring.cloud.kubernetes.config.retry.max-interval=3000",
+					"spring.cloud.kubernetes.config.retry.multiplier=1.5" })
+	@Nested
+	public class ConfigMapFailFastEnabledWithCustomRetryConfiguration {
+
+		@Autowired
+		ConfigMapConfigProperties configMapConfigProperties;
+
+		@Test
+		public void retryConfigurationShouldBeCustomized() {
+			RetryProperties retryProperties = configMapConfigProperties.getRetry();
+
+			assertThat(retryProperties.getMaxAttempts()).isEqualTo(3);
+			assertThat(retryProperties.getInitialInterval()).isEqualTo(1500L);
+			assertThat(retryProperties.getMaxInterval()).isEqualTo(3000L);
+			assertThat(retryProperties.getMultiplier()).isEqualTo(1.5D);
+		}
+
+	}
+
+	@SpringBootTest(webEnvironment = WebEnvironment.NONE, classes = App.class,
+			properties = { "spring.cloud.kubernetes.secrets.fail-fast=true",
+					"spring.cloud.kubernetes.secrets.retry.max-attempts=3",
+					"spring.cloud.kubernetes.secrets.retry.initial-interval=1500",
+					"spring.cloud.kubernetes.secrets.retry.max-interval=3000",
+					"spring.cloud.kubernetes.secrets.retry.multiplier=1.5" })
+	@Nested
+	public class SecretsFailFastEnabledWithCustomRetryConfiguration {
+
+		@Autowired
+		SecretsConfigProperties secretsConfigProperties;
+
+		@Test
+		public void retryConfigurationShouldBeCustomized() {
+			RetryProperties retryProperties = secretsConfigProperties.getRetry();
+
+			assertThat(retryProperties.getMaxAttempts()).isEqualTo(3);
+			assertThat(retryProperties.getInitialInterval()).isEqualTo(1500L);
+			assertThat(retryProperties.getMaxInterval()).isEqualTo(3000L);
+			assertThat(retryProperties.getMultiplier()).isEqualTo(1.5D);
+		}
+
+	}
+
+	@Nested
+	public class FailFastEnabledWithoutSpringRetryOnClasspath {
+
+		private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+				.withConfiguration(AutoConfigurations.of(KubernetesBootstrapConfiguration.class))
+				.withClassLoader(new FilteredClassLoader(Retryable.class, Aspect.class, AopAutoConfiguration.class));
+
+		@Test
+		public void shouldNotDefineRetryBeansWhenConfigMapFailFastEnabled() {
+			contextRunner.withPropertyValues("spring.cloud.kubernetes.config.fail-fast=true")
+					.run(context -> assertThat(context.getBeansOfType(RetryOperationsInterceptor.class)).isEmpty());
+		}
+
+		@Test
+		public void shouldNotDefineRetryBeansWhenSecretsFailFastEnabled() {
+			contextRunner.withPropertyValues("spring.cloud.kubernetes.secrets.fail-fast=true")
+					.run(context -> assertThat(context.getBeansOfType(RetryOperationsInterceptor.class)).isEmpty());
+		}
+
+		@Test
+		public void shouldNotDefineRetryBeansWhenConfigMapAndSecretsFailFastEnabled() {
+			contextRunner
+					.withPropertyValues("spring.cloud.kubernetes.config.fail-fast=true",
+							"spring.cloud.kubernetes.secrets.fail-fast=true")
+					.run(context -> assertThat(context.getBeansOfType(RetryOperationsInterceptor.class)).isEmpty());
+		}
+
+	}
+
+	@SpringBootApplication
+	static class App {
+
+	}
+
+}

--- a/spring-cloud-kubernetes-dependencies/pom.xml
+++ b/spring-cloud-kubernetes-dependencies/pom.xml
@@ -40,6 +40,7 @@
 		<istio-client.version>1.7.7.1</istio-client.version>
 		<mockwebserver.version>0.1.2</mockwebserver.version>
 		<wiremock.version>2.26.3</wiremock.version>
+		<spring-retry.version>1.3.1</spring-retry.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -71,6 +72,12 @@
 				<groupId>me.snowdrop</groupId>
 				<artifactId>istio-client</artifactId>
 				<version>${istio-client.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.retry</groupId>
+				<artifactId>spring-retry</artifactId>
+				<version>${spring-retry.version}</version>
 			</dependency>
 
 			<!-- Own dependencies -->

--- a/spring-cloud-kubernetes-fabric8-config/pom.xml
+++ b/spring-cloud-kubernetes-fabric8-config/pom.xml
@@ -179,6 +179,17 @@
 			<version>${groovy.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySource.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,13 +38,14 @@ import static org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigU
  * @author Ioannis Canellos
  * @author Ali Shahbour
  * @author Michael Moudatsos
+ * @author Isik Erhan
  */
 public class Fabric8ConfigMapPropertySource extends ConfigMapPropertySource {
 
 	private static final Log LOG = LogFactory.getLog(Fabric8ConfigMapPropertySource.class);
 
 	public Fabric8ConfigMapPropertySource(KubernetesClient client, String name) {
-		this(client, name, null, null, "");
+		this(client, name, null, null, "", false);
 	}
 
 	/**
@@ -54,18 +55,19 @@ public class Fabric8ConfigMapPropertySource extends ConfigMapPropertySource {
 	@Deprecated
 	public Fabric8ConfigMapPropertySource(KubernetesClient client, String applicationName, String namespace,
 			Environment environment) {
-		super(getName(applicationName, getApplicationNamespace(client, namespace)),
-				getData(client, applicationName, getApplicationNamespace(client, namespace), environment, ""));
+		this(client, applicationName, namespace, environment, "", false);
 	}
 
 	public Fabric8ConfigMapPropertySource(KubernetesClient client, String applicationName, String namespace,
-			Environment environment, String prefix) {
-		super(getName(applicationName, getApplicationNamespace(client, namespace)),
-				getData(client, applicationName, getApplicationNamespace(client, namespace), environment, prefix));
+			Environment environment, String prefix, boolean failFast) {
+		super(getName(applicationName, getApplicationNamespace(client, namespace)), getData(client, applicationName,
+				getApplicationNamespace(client, namespace), environment, prefix, failFast));
 	}
 
 	private static Map<String, Object> getData(KubernetesClient client, String applicationName, String namespace,
-			Environment environment, String prefix) {
+			Environment environment, String prefix, boolean failFast) {
+
+		LOG.info("Loading ConfigMap with name '" + applicationName + "' in namespace '" + namespace + "'");
 		try {
 			Map<String, String> data = getConfigMapData(client, namespace, applicationName);
 			Map<String, Object> result = new HashMap<>(processAllEntries(data, environment));
@@ -88,6 +90,12 @@ public class Fabric8ConfigMapPropertySource extends ConfigMapPropertySource {
 
 		}
 		catch (Exception e) {
+			if (failFast) {
+				throw new IllegalStateException(
+						"Unable to read ConfigMap with name '" + applicationName + "' in namespace '" + namespace + "'",
+						e);
+			}
+
 			LOG.warn("Can't read configMap with name: [" + applicationName + "] in namespace: [" + namespace
 					+ "]. Ignoring.", e);
 		}

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import static org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigU
  *
  * @author Ioannis Canellos
  * @author Michael Moudatsos
+ * @author Isik Erhan
  */
 @Order(0)
 public class Fabric8ConfigMapPropertySourceLocator extends ConfigMapPropertySourceLocator {
@@ -69,7 +70,7 @@ public class Fabric8ConfigMapPropertySourceLocator extends ConfigMapPropertySour
 		String namespace = getApplicationNamespace(this.client, normalizedSource.getNamespace(), configurationTarget,
 				provider);
 		return new Fabric8ConfigMapPropertySource(this.client, applicationName, namespace, environment,
-				normalizedSource.getPrefix());
+				normalizedSource.getPrefix(), this.properties.isFailFast());
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import static org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigU
  *
  * @author l burgazzoli
  * @author Haytham Mohamed
+ * @author Isik Erhan
  */
 @Order(1)
 public class Fabric8SecretsPropertySourceLocator extends SecretsPropertySourceLocator {
@@ -72,7 +73,8 @@ public class Fabric8SecretsPropertySourceLocator extends SecretsPropertySourceLo
 		String secretNamespace = getApplicationNamespace(this.client, normalizedSource.getNamespace(),
 				configurationTarget, provider);
 		Map<String, String> labels = normalizedSource.getLabels();
-		return new Fabric8SecretsPropertySource(this.client, secretName, secretNamespace, labels);
+		return new Fabric8SecretsPropertySource(this.client, secretName, secretNamespace, labels,
+				this.properties.isFailFast());
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceLocatorRetryTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceLocatorRetryTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Isik Erhan
+ */
+@EnableKubernetesMockClient
+public class Fabric8ConfigMapPropertySourceLocatorRetryTests {
+
+	private static final String API = "/api/v1/namespaces/default/configmaps/application";
+
+	static KubernetesMockServer mockServer;
+
+	static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setup() {
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_HTTP2_DISABLE, "true");
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default",
+					"spring.cloud.kubernetes.config.fail-fast=true",
+					"spring.cloud.kubernetes.config.retry.max-attempts=5" },
+			classes = Application.class)
+	@EnableKubernetesMockClient
+	class ConfigMapRetryEnabled {
+
+		@SpyBean
+		private Fabric8ConfigMapPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetryWhenThereIsNoFailure() {
+			Map<String, String> data = new HashMap<>();
+			data.put("some.prop", "theValue");
+			data.put("some.number", "0");
+
+			// return config map without failing
+			mockServer.expect().withPath(API).andReturn(200, new ConfigMapBuilder().withNewMetadata()
+					.withName("application").endMetadata().addToData(data).build()).once();
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.prop")).isEqualTo("theValue");
+			assertThat(propertySource.getProperty("some.number")).isEqualTo("0");
+		}
+
+		@Test
+		public void locateShouldRetryAndRecover() {
+			Map<String, String> data = new HashMap<>();
+			data.put("some.prop", "theValue");
+			data.put("some.number", "0");
+
+			// fail 3 times then succeed at the 4th call
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").times(3);
+			mockServer.expect().withPath(API).andReturn(200, new ConfigMapBuilder().withNewMetadata()
+					.withName("application").endMetadata().addToData(data).build()).once();
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify retried 4 times
+			verify(propertySourceLocator, times(4)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.prop")).isEqualTo("theValue");
+			assertThat(propertySource.getProperty("some.number")).isEqualTo("0");
+		}
+
+		@Test
+		public void locateShouldRetryAndFail() {
+			// fail all the 5 requests
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").times(5);
+
+			assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessage("Unable to read ConfigMap with name 'application' in namespace 'default'");
+
+			// verify retried 5 times until failure
+			verify(propertySourceLocator, times(5)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default" }, classes = Application.class)
+	@EnableKubernetesMockClient
+	class ConfigMapRetryDisabled {
+
+		@SpyBean
+		private Fabric8ConfigMapPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetry() {
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
+
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify that propertySourceLocator.locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+			"spring.cloud.kubernetes.client.namespace=default", "spring.cloud.kubernetes.secrets.fail-fast=true" },
+			classes = Application.class)
+	@EnableKubernetesMockClient
+	class ConfigMapRetryDisabledButSecretsRetryEnabled {
+
+		@SpyBean
+		private Fabric8ConfigMapPropertySourceLocator propertySourceLocator;
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Test
+		public void locateShouldNotRetry() {
+
+			/*
+			 * Enabling secrets fail-fast causes Spring Retry to be enabled and a
+			 * RetryOperationsInterceptor bean with NeverRetryPolicy for config maps to be
+			 * defined. ConfigMapPropertySourceLocator should not retry even Spring Retry
+			 * is enabled.
+			 */
+
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
+
+			assertThat(context.containsBean("configMapPropertiesRetryInterceptor")).isTrue();
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify that propertySourceLocator.locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceLocatorTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceLocatorTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.cloud.kubernetes.commons.config.ConfigMapConfigProperties;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Isik Erhan
+ */
+@EnableKubernetesMockClient
+public class Fabric8ConfigMapPropertySourceLocatorTests {
+
+	KubernetesMockServer mockServer;
+
+	KubernetesClient mockClient;
+
+	@Test
+	public void locateShouldThrowExceptionOnFailureWhenFailFastIsEnabled() {
+		final String name = "my-config";
+		final String namespace = "default";
+		final String path = String.format("/api/v1/namespaces/%s/configmaps/%s", namespace, name);
+
+		mockServer.expect().withPath(path).andReturn(500, "Internal Server Error").once();
+
+		ConfigMapConfigProperties configMapConfigProperties = new ConfigMapConfigProperties();
+		configMapConfigProperties.setName(name);
+		configMapConfigProperties.setNamespace(namespace);
+		configMapConfigProperties.setFailFast(true);
+
+		Fabric8ConfigMapPropertySourceLocator locator = new Fabric8ConfigMapPropertySourceLocator(mockClient,
+				configMapConfigProperties, new KubernetesNamespaceProvider(new MockEnvironment()));
+
+		assertThatThrownBy(() -> locator.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Unable to read ConfigMap with name '" + name + "' in namespace '" + namespace + "'");
+	}
+
+	@Test
+	public void locateShouldNotThrowExceptionOnFailureWhenFailFastIsDisabled() {
+		final String name = "my-config";
+		final String namespace = "default";
+		final String path = String.format("/api/v1/namespaces/%s/configmaps/%s", namespace, name);
+
+		mockServer.expect().withPath(path).andReturn(500, "Internal Server Error").once();
+
+		ConfigMapConfigProperties configMapConfigProperties = new ConfigMapConfigProperties();
+		configMapConfigProperties.setName(name);
+		configMapConfigProperties.setNamespace(namespace);
+		configMapConfigProperties.setFailFast(false);
+
+		Fabric8ConfigMapPropertySourceLocator locator = new Fabric8ConfigMapPropertySourceLocator(mockClient,
+				configMapConfigProperties, new KubernetesNamespaceProvider(new MockEnvironment()));
+
+		assertThatNoException().isThrownBy(() -> locator.locate(new MockEnvironment()));
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigMapPropertySourceTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Isik Erhan
+ */
+@EnableKubernetesMockClient
+public class Fabric8ConfigMapPropertySourceTests {
+
+	KubernetesMockServer mockServer;
+
+	KubernetesClient mockClient;
+
+	@Test
+	public void constructorShouldThrowExceptionOnFailureWhenFailFastIsEnabled() {
+		final String name = "my-config";
+		final String namespace = "default";
+		final String path = String.format("/api/v1/namespaces/%s/configmaps/%s", namespace, name);
+
+		mockServer.expect().withPath(path).andReturn(500, "Internal Server Error").once();
+		assertThatThrownBy(
+				() -> new Fabric8ConfigMapPropertySource(mockClient, name, namespace, new MockEnvironment(), "", true))
+						.isInstanceOf(IllegalStateException.class).hasMessage(
+								"Unable to read ConfigMap with name '" + name + "' in namespace '" + namespace + "'");
+	}
+
+	@Test
+	public void constructorShouldNotThrowExceptionOnFailureWhenFailFastIsDisabled() {
+		final String name = "my-config";
+		final String namespace = "default";
+		final String path = String.format("/api/v1/namespaces/%s/configmaps/%s", namespace, name);
+
+		mockServer.expect().withPath(path).andReturn(500, "Internal Server Error").once();
+		assertThatNoException().isThrownBy(() -> new Fabric8ConfigMapPropertySource(mockClient, name, namespace,
+				new MockEnvironment(), "", false));
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceLocatorRetryTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceLocatorRetryTests.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.SecretListBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Isik Erhan
+ */
+@EnableKubernetesMockClient
+public class Fabric8SecretsPropertySourceLocatorRetryTests {
+
+	private static final String API = "/api/v1/namespaces/default/secrets/my-secret";
+
+	private static final String LIST_API = "/api/v1/namespaces/default/secrets";
+
+	static KubernetesMockServer mockServer;
+
+	static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setup() {
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_HTTP2_DISABLE, "true");
+
+		// return empty secret list to not fail context creation
+		mockServer.expect().withPath(LIST_API).andReturn(200, new SecretListBuilder().build()).always();
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+			"spring.cloud.kubernetes.client.namespace=default", "spring.cloud.kubernetes.secrets.fail-fast=true",
+			"spring.cloud.kubernetes.secrets.retry.max-attempts=5", "spring.cloud.kubernetes.secrets.name=my-secret",
+			"spring.cloud.kubernetes.secrets.enable-api=true" }, classes = Application.class)
+	@EnableKubernetesMockClient
+	class SecretsRetryEnabled {
+
+		@SpyBean
+		private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetryWhenThereIsNoFailure() {
+			Map<String, String> data = new HashMap<>();
+			data.put("some.sensitive.prop", Base64.getEncoder().encodeToString("theSensitiveValue".getBytes()));
+			data.put("some.sensitive.number", Base64.getEncoder().encodeToString("1".getBytes()));
+
+			// return secret without failing
+			mockServer.expect().withPath(API).andReturn(200,
+					new SecretBuilder().withNewMetadata().withName("my-secret").endMetadata().addToData(data).build())
+					.once();
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.sensitive.prop")).isEqualTo("theSensitiveValue");
+			assertThat(propertySource.getProperty("some.sensitive.number")).isEqualTo("1");
+		}
+
+		@Test
+		public void locateShouldRetryAndRecover() {
+			Map<String, String> data = new HashMap<>();
+			data.put("some.sensitive.prop", Base64.getEncoder().encodeToString("theSensitiveValue".getBytes()));
+			data.put("some.sensitive.number", Base64.getEncoder().encodeToString("1".getBytes()));
+
+			// fail 3 times then succeed at the 4th call
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").times(3);
+			mockServer.expect().withPath(API).andReturn(200,
+					new SecretBuilder().withNewMetadata().withName("my-secret").endMetadata().addToData(data).build())
+					.once();
+
+			PropertySource<?> propertySource = Assertions
+					.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify retried 4 times
+			verify(propertySourceLocator, times(4)).locate(any());
+
+			// validate the contents of the property source
+			assertThat(propertySource.getProperty("some.sensitive.prop")).isEqualTo("theSensitiveValue");
+			assertThat(propertySource.getProperty("some.sensitive.number")).isEqualTo("1");
+		}
+
+		@Test
+		public void locateShouldRetryAndFail() {
+			// fail all the 5 requests
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").times(5);
+
+			assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessage("Unable to read Secret with name 'my-secret' or labels [{}] in namespace 'default'");
+
+			// verify retried 5 times until failure
+			verify(propertySourceLocator, times(5)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default",
+					"spring.cloud.kubernetes.secrets.name=my-secret",
+					"spring.cloud.kubernetes.secrets.enable-api=true" },
+			classes = Application.class)
+	@EnableKubernetesMockClient
+	class SecretsRetryDisabled {
+
+		@SpyBean
+		private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+		@Test
+		public void locateShouldNotRetry() {
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
+
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+			properties = { "spring.cloud.kubernetes.client.namespace=default",
+					"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.secrets.name=my-secret",
+					"spring.cloud.kubernetes.secrets.enable-api=true" },
+			classes = Application.class)
+	@EnableKubernetesMockClient
+	class SecretsRetryDisabledButConfigMapRetryEnabled {
+
+		@SpyBean
+		private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Test
+		public void locateShouldNotRetry() {
+
+			/*
+			 * Enabling config map fail-fast causes Spring Retry to be enabled and a
+			 * RetryOperationsInterceptor bean with NeverRetryPolicy for secrets to be
+			 * defined. SecretsPropertySourceLocator should not retry even Spring Retry is
+			 * enabled.
+			 */
+
+			mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
+
+			assertThat(context.containsBean("secretsPropertiesRetryInterceptor")).isTrue();
+			Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+
+			// verify that propertySourceLocator.locate is called only once
+			verify(propertySourceLocator, times(1)).locate(any());
+		}
+
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceLocatorTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceLocatorTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.cloud.kubernetes.commons.config.SecretsConfigProperties;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Isik Erhan
+ */
+@EnableKubernetesMockClient
+public class Fabric8SecretsPropertySourceLocatorTests {
+
+	KubernetesMockServer mockServer;
+
+	KubernetesClient mockClient;
+
+	@Test
+	public void locateShouldThrowExceptionOnFailureWhenFailFastIsEnabled() {
+		final String name = "my-config";
+		final String namespace = "default";
+		final String path = String.format("/api/v1/namespaces/%s/secrets/%s", namespace, name);
+
+		mockServer.expect().withPath(path).andReturn(500, "Internal Server Error").once();
+
+		SecretsConfigProperties configMapConfigProperties = new SecretsConfigProperties();
+		configMapConfigProperties.setName(name);
+		configMapConfigProperties.setNamespace(namespace);
+		configMapConfigProperties.setEnableApi(true);
+		configMapConfigProperties.setFailFast(true);
+
+		Fabric8SecretsPropertySourceLocator locator = new Fabric8SecretsPropertySourceLocator(mockClient,
+				configMapConfigProperties, new KubernetesNamespaceProvider(new MockEnvironment()));
+
+		assertThatThrownBy(() -> locator.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
+				.hasMessage("Unable to read Secret with name '" + name + "' or labels [{}] in namespace '" + namespace
+						+ "'");
+	}
+
+	@Test
+	public void locateShouldNotThrowExceptionOnFailureWhenFailFastIsDisabled() {
+		final String name = "my-config";
+		final String namespace = "default";
+		final String path = String.format("/api/v1/namespaces/%s/secrets/%s", namespace, name);
+
+		mockServer.expect().withPath(path).andReturn(500, "Internal Server Error").once();
+
+		SecretsConfigProperties configMapConfigProperties = new SecretsConfigProperties();
+		configMapConfigProperties.setName(name);
+		configMapConfigProperties.setNamespace(namespace);
+		configMapConfigProperties.setEnableApi(true);
+		configMapConfigProperties.setFailFast(false);
+
+		Fabric8SecretsPropertySourceLocator locator = new Fabric8SecretsPropertySourceLocator(mockClient,
+				configMapConfigProperties, new KubernetesNamespaceProvider(new MockEnvironment()));
+
+		assertThatNoException().isThrownBy(() -> locator.locate(new MockEnvironment()));
+	}
+
+}


### PR DESCRIPTION
Hello,

This PR adds support for fail fast and retry loading Kubernetes ConfigMaps and Secrets to resolve issues #769 and #441. There are some PRs around about these, but they seem to be stalled.

Thank you.