### PR TITLE
Add support for filtering by service-labels to Informer based DiscoveyClient

### DIFF
--- a/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesDiscoveryClientAutoConfiguration.java
+++ b/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesDiscoveryClientAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.cloud.kubernetes.commons.discovery.KubernetesDiscover
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnKubernetesDiscoveryEnabled
@@ -80,11 +81,15 @@ public class KubernetesDiscoveryClientAutoConfiguration {
 		@Bean
 		@ConditionalOnMissingBean
 		public SpringCloudKubernetesInformerFactoryProcessor discoveryInformerConfigurer(
-				KubernetesNamespaceProvider kubernetesNamespaceProvider,
-				KubernetesDiscoveryProperties kubernetesDiscoveryProperties, ApiClient apiClient,
-				CatalogSharedInformerFactory sharedInformerFactory) {
-			return new SpringCloudKubernetesInformerFactoryProcessor(kubernetesDiscoveryProperties,
-					kubernetesNamespaceProvider, apiClient, sharedInformerFactory);
+				KubernetesNamespaceProvider kubernetesNamespaceProvider, ApiClient apiClient,
+				CatalogSharedInformerFactory sharedInformerFactory, Environment environment) {
+			// Injecting KubernetesDiscoveryProperties here would cause it to be
+			// initialize too early
+			// Instead get the all-namespaces property value from the Environment directly
+			boolean allNamespaces = environment.getProperty("spring.cloud.kubernetes.discovery.all-namespaces",
+					Boolean.class, false);
+			return new SpringCloudKubernetesInformerFactoryProcessor(kubernetesNamespaceProvider, apiClient,
+					sharedInformerFactory, allNamespaces);
 		}
 
 		@Bean

--- a/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesInformerDiscoveryClient.java
+++ b/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesInformerDiscoveryClient.java
@@ -102,7 +102,7 @@ public class KubernetesInformerDiscoveryClient implements DiscoveryClient, Initi
 		V1Service service = properties.isAllNamespaces() ? this.serviceLister.list().stream()
 				.filter(svc -> serviceId.equals(svc.getMetadata().getName())).findFirst().orElse(null)
 				: this.serviceLister.namespace(this.namespace).get(serviceId);
-		if (service == null) {
+		if (service == null || !matchServiceLabels(service)) {
 			// no such service present in the cluster
 			return new ArrayList<>();
 		}
@@ -205,8 +205,8 @@ public class KubernetesInformerDiscoveryClient implements DiscoveryClient, Initi
 	public List<String> getServices() {
 		List<V1Service> services = this.properties.isAllNamespaces() ? this.serviceLister.list()
 				: this.serviceLister.namespace(this.namespace).list();
-		return services.stream().filter(s -> s.getMetadata() != null) // safeguard
-				.map(s -> s.getMetadata().getName()).collect(Collectors.toList());
+		return services.stream().filter(this::matchServiceLabels).map(s -> s.getMetadata().getName())
+				.collect(Collectors.toList());
 	}
 
 	@Override
@@ -228,6 +228,30 @@ public class KubernetesInformerDiscoveryClient implements DiscoveryClient, Initi
 		}
 		log.info("Cache fully loaded (total " + serviceLister.list().size()
 				+ " services) , discovery client is now available");
+	}
+
+	private boolean matchServiceLabels(V1Service service) {
+		if (log.isDebugEnabled()) {
+			log.debug("Kubernetes Service Label Properties:");
+			if (this.properties.getServiceLabels() != null) {
+				this.properties.getServiceLabels().forEach((key, value) -> log.debug(key + ":" + value));
+			}
+			log.debug("Service " + service.getMetadata().getName() + " labels:");
+			if (service.getMetadata() != null && service.getMetadata().getLabels() != null) {
+				service.getMetadata().getLabels().forEach((key, value) -> log.debug(key + ":" + value));
+			}
+		}
+		// safeguard
+		if (service.getMetadata() == null) {
+			return false;
+		}
+		if (properties.getServiceLabels() == null || properties.getServiceLabels().isEmpty()) {
+			return true;
+		}
+		return properties.getServiceLabels().keySet().stream()
+				.allMatch(k -> service.getMetadata().getLabels() != null
+						&& service.getMetadata().getLabels().containsKey(k)
+						&& service.getMetadata().getLabels().get(k).equals(properties.getServiceLabels().get(k)));
 	}
 
 }

--- a/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/SpringCloudKubernetesInformerFactoryProcessor.java
+++ b/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/SpringCloudKubernetesInformerFactoryProcessor.java
@@ -38,7 +38,6 @@ import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
-import org.springframework.cloud.kubernetes.commons.discovery.KubernetesDiscoveryProperties;
 import org.springframework.core.ResolvableType;
 
 /**
@@ -54,26 +53,24 @@ class SpringCloudKubernetesInformerFactoryProcessor extends KubernetesInformerFa
 
 	private final SharedInformerFactory sharedInformerFactory;
 
-	private final KubernetesDiscoveryProperties kubernetesDiscoveryProperties;
+	private final boolean allNamespaces;
 
 	private final KubernetesNamespaceProvider kubernetesNamespaceProvider;
 
 	@Autowired
-	SpringCloudKubernetesInformerFactoryProcessor(KubernetesDiscoveryProperties kubernetesDiscoveryProperties,
-			KubernetesNamespaceProvider kubernetesNamespaceProvider, ApiClient apiClient,
-			SharedInformerFactory sharedInformerFactory) {
+	SpringCloudKubernetesInformerFactoryProcessor(KubernetesNamespaceProvider kubernetesNamespaceProvider,
+			ApiClient apiClient, SharedInformerFactory sharedInformerFactory, boolean allNamespaces) {
 		super();
 		this.apiClient = apiClient;
 		this.sharedInformerFactory = sharedInformerFactory;
 		this.kubernetesNamespaceProvider = kubernetesNamespaceProvider;
-		this.kubernetesDiscoveryProperties = kubernetesDiscoveryProperties;
+		this.allNamespaces = allNamespaces;
 	}
 
 	@Override
 	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-		String namespace = kubernetesDiscoveryProperties.isAllNamespaces() ? Namespaces.NAMESPACE_ALL
-				: kubernetesNamespaceProvider.getNamespace() == null ? Namespaces.NAMESPACE_DEFAULT
-						: kubernetesNamespaceProvider.getNamespace();
+		String namespace = allNamespaces ? Namespaces.NAMESPACE_ALL : kubernetesNamespaceProvider.getNamespace() == null
+				? Namespaces.NAMESPACE_DEFAULT : kubernetesNamespaceProvider.getNamespace();
 
 		this.apiClient.setHttpClient(this.apiClient.getHttpClient().newBuilder().readTimeout(Duration.ZERO).build());
 


### PR DESCRIPTION
Fixes #810

This also fixes a problem where `KubernetesDiscoveryClient` was being initialized too early and properties were not being bound.