### PR TITLE
deps: bump JKube to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-		<kubernetes.maven.plugin.version>1.5.1</kubernetes.maven.plugin.version>
+		<kubernetes.maven.plugin.version>1.6.0</kubernetes.maven.plugin.version>
 		<groovy.version>2.4.12</groovy.version>
 		<restassured.version>3.0.2</restassured.version>
 

--- a/spring-cloud-kubernetes-integration-tests/pom.xml
+++ b/spring-cloud-kubernetes-integration-tests/pom.xml
@@ -63,12 +63,6 @@
 								<includes>
 									<include>spring-boot</include>
 								</includes>
-								<config>
-									<spring-boot>
-										<!-- TODO: Remove when Eclipse JKube 1.6.0 is released -->
-										<from>quay.io/jkube/jkube-java:0.0.13</from>
-									</spring-boot>
-								</config>
 							</generator>
 						</configuration>
 						<executions>


### PR DESCRIPTION
Eclipse JKube 1.6.0 was just released: https://github.com/eclipse/jkube/releases/tag/v1.6.0

- Bump Kubernetes Maven Plugin version
- Remove base image override (it's the same as the current default)