### PR TITLE
Discovery Server URL exception message fix

### DIFF
--- a/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/DiscoveryServerUrlInvalidException.java
+++ b/spring-cloud-kubernetes-discovery/src/main/java/org/springframework/cloud/kubernetes/discovery/DiscoveryServerUrlInvalidException.java
@@ -22,7 +22,7 @@ package org.springframework.cloud.kubernetes.discovery;
 public class DiscoveryServerUrlInvalidException extends RuntimeException {
 
 	public DiscoveryServerUrlInvalidException() {
-		super("spring.cloud.kubernetes.discovery-server-url must be specified and a valid URL.");
+		super("spring.cloud.kubernetes.discovery.discovery-server-url must be specified and a valid URL.");
 	}
 
 }


### PR DESCRIPTION
I saw a discrepancy between this Discovery Server URL exception and the actual path prefix for the Kubernetes Discovery  properties. This PR updates the exception message so it matches the path.

```java
@ConfigurationProperties("spring.cloud.kubernetes.discovery")
public class KubernetesDiscoveryClientProperties {

	private String discoveryServerUrl;

        ...
}
```

**Commits:**
* Updates `DiscoveryServerUrlInvalidException` message with appropriate property path.