### PR TITLE
Use ConfigData To Load Configuration From Kubernetes Instead Of Bootstrap

### DIFF
--- a/docs/src/main/asciidoc/kubernetes-awareness.adoc
+++ b/docs/src/main/asciidoc/kubernetes-awareness.adoc
@@ -14,10 +14,11 @@ that setting via `spring.main.cloud-platform`.
 
 For example, if you need to test some features, but do not want to deploy to a cluster, it is enough to set the:
 `spring.main.cloud-platform=KUBERNETES`. This will make `spring-cloud-kubernetes` act as-if it is deployed in a real cluster.
-Be aware that when `spring-cloud-kubernetes-config` is on the classpath, `spring.main.cloud-platform` should be set in `bootstrap.{properties|yml}`
-(or the profile specific one),  otherwise it should be in `application.{properties|yml}` (or the profile specific one).
-Also note that these properties: `spring.cloud.kubernetes.config.enabled` and `spring.cloud.kubernetes.secrets.enabled`
-only take effect when set in `bootstrap.{properties|yml}`.
+
+NOTE:  If you have `spring-cloud-bootstrap-starter` on your classpath or are setting `spring.cloud.bootstrap.enabled=true` then
+you will have to set `spring.main.cloud-platform` should be set in `bootstrap.{properties|yml}`
+(or the profile specific one).  Also note that these properties: `spring.cloud.kubernetes.config.enabled` and `spring.cloud.kubernetes.secrets.enabled`
+will only take effect when set in `bootstrap.{properties|yml}` when you have `spring-cloud-bootstrap-starter` on your classpath or are setting `spring.cloud.bootstrap.enabled=true`.
 
 === Breaking Changes In 3.0.x
 

--- a/docs/src/main/asciidoc/property-source-config.adoc
+++ b/docs/src/main/asciidoc/property-source-config.adoc
@@ -5,18 +5,27 @@ an `application-profile.properties` or `application-profile.yaml` file that cont
 application or Spring Boot starters. You can override these properties by specifying system properties or environment
 variables.
 
+To enable this functionality you need to set `spring.config.import=kubernetes:` in your application's configuration properties.
+Currently you can not specify a ConfigMap or Secret to load using `spring.config.import`, by default Spring Cloud Kubernetes
+will load a ConfigMap and/or Secret based on the `spring.application.name` property.  If `spring.application.name` is not set it will
+load a ConfigMap and/or Secret with the name `application`.
+
+If you would like to load Kubernetes `PropertySource`s during the bootstrap phase like it worked prior to the 3.0.x release
+you can either add `spring-cloud-starter-bootstrap` to your application's classpath or set `spring.cloud.bootstrap.enabled=true`
+as an environment variable.
+
 [[configmap-propertysource]]
 === Using a `ConfigMap` `PropertySource`
 
 Kubernetes provides a resource named https://kubernetes.io/docs/user-guide/configmap/[`ConfigMap`] to externalize the
 parameters to pass to your application in the form of key-value pairs or embedded `application.properties` or `application.yaml` files.
 The link:https://github.com/spring-cloud/spring-cloud-kubernetes/tree/master/spring-cloud-kubernetes-fabric8-config[Spring Cloud Kubernetes Config] project makes Kubernetes `ConfigMap` instances available
-during application bootstrapping and triggers hot reloading of beans or Spring context when changes are detected on
+during application startup and triggers hot reloading of beans or Spring context when changes are detected on
 observed `ConfigMap` instances.
 
 The default behavior is to create a `Fabric8ConfigMapPropertySource` based on a Kubernetes `ConfigMap` that has a `metadata.name` value of either the name of
 your Spring application (as defined by its `spring.application.name` property) or a custom name defined within the
-`bootstrap.properties` file under the following key: `spring.cloud.kubernetes.config.name`.
+`application.properties` file under the following key: `spring.cloud.kubernetes.config.name`.
 
 However, more advanced configuration is possible where you can use multiple `ConfigMap` instances.
 The `spring.cloud.kubernetes.config.sources` list makes this possible.
@@ -239,8 +248,8 @@ data:
 ====
 
 
-To tell Spring Boot which `profile` should be enabled at bootstrap, you can pass `SPRING_PROFILES_ACTIVE` environment variable.
- To do so, you can launch your Spring Boot application with an environment variable that you can define it in the PodSpec at the container specification.
+To tell Spring Boot which `profile` should be enabled see the https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.profiles[Spring Boot documentation].
+One option for activating a specific profile when deploying to Kubernetes is to launch your Spring Boot application with an environment variable that you can define in the PodSpec at the container specification.
  Deployment resource file, as follows:
 
 ====

--- a/spring-cloud-kubernetes-client-config/pom.xml
+++ b/spring-cloud-kubernetes-client-config/pom.xml
@@ -54,10 +54,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bootstrap</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.retry</groupId>
 			<artifactId>spring-retry</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigDataLocationResolver.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import org.apache.commons.logging.Log;
+
+import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
+import org.springframework.boot.ConfigurableBootstrapContext;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.cloud.kubernetes.client.KubernetesClientPodUtils;
+import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableSecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.ConfigMapConfigProperties;
+import org.springframework.cloud.kubernetes.commons.config.ConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.KubernetesConfigDataLocationResolver;
+import org.springframework.cloud.kubernetes.commons.config.SecretsConfigProperties;
+import org.springframework.cloud.kubernetes.commons.config.SecretsPropertySourceLocator;
+import org.springframework.core.env.Environment;
+
+import static org.springframework.cloud.kubernetes.client.KubernetesClientUtils.kubernetesApiClient;
+
+/**
+ * @author Ryan Baxter
+ */
+public class KubernetesClientConfigDataLocationResolver extends KubernetesConfigDataLocationResolver {
+
+	public KubernetesClientConfigDataLocationResolver(Log log) {
+		super(log);
+	}
+
+	@Override
+	protected void registerBeans(ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location,
+			Profiles profiles, KubernetesConfigDataLocationResolver.PropertyHolder propertyHolder,
+			KubernetesNamespaceProvider namespaceProvider) {
+		String uris = location.getNonPrefixedValue(getPrefix());
+		KubernetesClientProperties properties = propertyHolder.kubernetesClientProperties;
+		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapProperties;
+		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties;
+
+		ConfigurableBootstrapContext bootstrapContext = resolverContext.getBootstrapContext();
+		ApiClient apiClient = kubernetesApiClient();
+		bootstrapContext.registerIfAbsent(ApiClient.class, InstanceSupplier.of(apiClient));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+				.registerSingleton("configDataApiClient", event.getBootstrapContext().get(ApiClient.class)));
+
+		CoreV1Api coreV1Api = coreApi(apiClient);
+		bootstrapContext.registerIfAbsent(CoreV1Api.class, InstanceSupplier.of(coreV1Api));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+				.registerSingleton("configCoreV1Api", event.getBootstrapContext().get(CoreV1Api.class)));
+
+		if (isRetryEnabled(configMapProperties, secretsProperties)) {
+			registerRetryBeans(configMapProperties, secretsProperties, bootstrapContext, coreV1Api, namespaceProvider);
+		}
+		else {
+			if (configMapProperties.isEnabled()) {
+				KubernetesClientConfigMapPropertySourceLocator configMapPropertySourceLocator = new KubernetesClientConfigMapPropertySourceLocator(
+						coreV1Api, configMapProperties, namespaceProvider);
+				bootstrapContext.registerIfAbsent(ConfigMapPropertySourceLocator.class,
+						InstanceSupplier.of(configMapPropertySourceLocator));
+				bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+						.registerSingleton("configDataConfigMapPropertySourceLocator",
+								event.getBootstrapContext().get(ConfigMapPropertySourceLocator.class)));
+			}
+
+			if (secretsProperties.isEnabled()) {
+				KubernetesClientSecretsPropertySourceLocator secretsPropertySourceLocator = new KubernetesClientSecretsPropertySourceLocator(
+						coreV1Api, namespaceProvider, secretsProperties);
+				bootstrapContext.registerIfAbsent(SecretsPropertySourceLocator.class,
+						InstanceSupplier.of(secretsPropertySourceLocator));
+				bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+						.registerSingleton("configDataSecretsPropertySourceLocator",
+								event.getBootstrapContext().get(SecretsPropertySourceLocator.class)));
+			}
+		}
+	}
+
+	private void registerRetryBeans(ConfigMapConfigProperties configMapProperties,
+			SecretsConfigProperties secretsProperties, ConfigurableBootstrapContext bootstrapContext,
+			CoreV1Api coreV1Api, KubernetesNamespaceProvider namespaceProvider) {
+		if (configMapProperties.isEnabled()) {
+			ConfigMapPropertySourceLocator configMapPropertySourceLocator = new KubernetesClientConfigMapPropertySourceLocator(
+					coreV1Api, configMapProperties, namespaceProvider);
+			if (isRetryEnabledForConfigMap(configMapProperties)) {
+				configMapPropertySourceLocator = new ConfigDataRetryableConfigMapPropertySourceLocator(
+						configMapPropertySourceLocator, configMapProperties);
+			}
+
+			bootstrapContext.registerIfAbsent(ConfigMapPropertySourceLocator.class,
+					InstanceSupplier.of(configMapPropertySourceLocator));
+			bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+					"configDataConfigMapPropertySourceLocator",
+					event.getBootstrapContext().get(ConfigMapPropertySourceLocator.class)));
+		}
+
+		if (secretsProperties.isEnabled()) {
+			SecretsPropertySourceLocator secretsPropertySourceLocator = new KubernetesClientSecretsPropertySourceLocator(
+					coreV1Api, namespaceProvider, secretsProperties);
+			if (isRetryEnabledForSecrets(secretsProperties)) {
+				secretsPropertySourceLocator = new ConfigDataRetryableSecretsPropertySourceLocator(
+						secretsPropertySourceLocator, secretsProperties);
+			}
+
+			bootstrapContext.registerIfAbsent(SecretsPropertySourceLocator.class,
+					InstanceSupplier.of(secretsPropertySourceLocator));
+			bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+					"configDataSecretsPropertySourceLocator",
+					event.getBootstrapContext().get(SecretsPropertySourceLocator.class)));
+		}
+	}
+
+	protected ApiClient apiClient(KubernetesClientProperties properties) {
+		ApiClient apiClient = kubernetesApiClient();
+		apiClient.setUserAgent(properties.getUserAgent());
+		return apiClient;
+	}
+
+	protected CoreV1Api coreApi(ApiClient apiClient) {
+		return new CoreV1Api(apiClient);
+	}
+
+	protected KubernetesNamespaceProvider kubernetesNamespaceProvider(Environment environment) {
+		return new KubernetesNamespaceProvider(environment);
+	}
+
+	protected KubernetesClientPodUtils kubernetesPodUtils(CoreV1Api client,
+			KubernetesNamespaceProvider kubernetesNamespaceProvider) {
+		return new KubernetesClientPodUtils(client, kubernetesNamespaceProvider.getNamespace());
+	}
+
+}

--- a/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigDataLocationResolver.java
@@ -18,13 +18,13 @@ package org.springframework.cloud.kubernetes.client.config;
 
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
-import org.apache.commons.logging.Log;
 
 import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
 import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.cloud.kubernetes.client.KubernetesClientPodUtils;
 import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
 import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
@@ -44,8 +44,8 @@ import static org.springframework.cloud.kubernetes.client.KubernetesClientUtils.
  */
 public class KubernetesClientConfigDataLocationResolver extends KubernetesConfigDataLocationResolver {
 
-	public KubernetesClientConfigDataLocationResolver(Log log) {
-		super(log);
+	public KubernetesClientConfigDataLocationResolver(DeferredLogFactory factory) {
+		super(factory);
 	}
 
 	@Override

--- a/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-client-config/src/main/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigDataLocationResolver.java
@@ -52,10 +52,8 @@ public class KubernetesClientConfigDataLocationResolver extends KubernetesConfig
 	protected void registerBeans(ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location,
 			Profiles profiles, KubernetesConfigDataLocationResolver.PropertyHolder propertyHolder,
 			KubernetesNamespaceProvider namespaceProvider) {
-		String uris = location.getNonPrefixedValue(getPrefix());
-		KubernetesClientProperties properties = propertyHolder.kubernetesClientProperties;
-		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapProperties;
-		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties;
+		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapConfigProperties();
+		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties();
 
 		ConfigurableBootstrapContext bootstrapContext = resolverContext.getBootstrapContext();
 		ApiClient apiClient = kubernetesApiClient();

--- a/spring-cloud-kubernetes-client-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-kubernetes-client-config/src/main/resources/META-INF/spring.factories
@@ -3,3 +3,6 @@ org.springframework.cloud.kubernetes.client.config.reload.KubernetesClientConfig
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.kubernetes.client.config.KubernetesClientBootstrapConfiguration,\
 org.springframework.cloud.kubernetes.client.config.KubernetesClientRetryBootstrapConfiguration
+# ConfigData Location Resolvers
+org.springframework.boot.context.config.ConfigDataLocationResolver=\
+org.springframework.cloud.kubernetes.client.config.KubernetesClientConfigDataLocationResolver

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapBootstrapIncludeProfileSpecificSourcesTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapBootstrapIncludeProfileSpecificSourcesTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.client.config.applications.include_profile_specific_sources.IncludeProfileSpecificSourcesApp;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * The stub data for this test is in : IncludeProfileSpecificSourcesConfigurationStub
+ *
+ * @author wind57
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = IncludeProfileSpecificSourcesApp.class,
+		properties = { "spring.cloud.bootstrap.name=include-profile-specific-sources",
+				"include.profile.specific.sources=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@ActiveProfiles("dev")
+class KubernetesClientConfigMapBootstrapIncludeProfileSpecificSourcesTests
+		extends KubernetesClientConfigMapIncludeProfileSpecificSourcesTests {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapBootstrapNameAsPrefixTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapBootstrapNameAsPrefixTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.client.config.applications.config_map_name_as_prefix.WithPrefixApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Ryan Baxter
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = WithPrefixApp.class,
+		properties = { "spring.cloud.bootstrap.name=config-map-name-as-prefix", "config.map.name.as.prefix.stub=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+public class KubernetesClientConfigMapBootstrapNameAsPrefixTests extends KubernetesClientConfigMapNameAsPrefixTests {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapConfigDataIncludeProfileSpecificSourcesTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapConfigDataIncludeProfileSpecificSourcesTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kubernetes.client.util.ClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
+import org.springframework.cloud.kubernetes.client.config.applications.include_profile_specific_sources.IncludeProfileSpecificSourcesApp;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.mockito.Mockito.mockStatic;
+import static org.springframework.cloud.kubernetes.client.config.boostrap.stubs.IncludeProfileSpecificSourcesConfigurationStub.stubData;
+
+/**
+ * @author Ryan Baxter
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = IncludeProfileSpecificSourcesApp.class,
+		properties = { "spring.application.name=include-profile-specific-sources",
+				"include.profile.specific.sources=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./include-profile-specific-sources.yaml" })
+@AutoConfigureWebTestClient
+@ActiveProfiles("dev")
+public class KubernetesClientConfigMapConfigDataIncludeProfileSpecificSourcesTests
+		extends KubernetesClientConfigMapIncludeProfileSpecificSourcesTests {
+
+	private static MockedStatic<KubernetesClientUtils> clientUtilsMock;
+
+	@BeforeAll
+	public static void wireMock() {
+		WireMockServer server = new WireMockServer(options().dynamicPort());
+		server.start();
+		WireMock.configureFor("localhost", server.port());
+		clientUtilsMock = mockStatic(KubernetesClientUtils.class);
+		clientUtilsMock.when(KubernetesClientUtils::kubernetesApiClient)
+				.thenReturn(new ClientBuilder().setBasePath(server.baseUrl()).build());
+		stubData();
+	}
+
+	@AfterAll
+	static void teardown() {
+		clientUtilsMock.close();
+	}
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapConfigDataNameAsPrefixTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapConfigDataNameAsPrefixTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kubernetes.client.util.ClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
+import org.springframework.cloud.kubernetes.client.config.applications.config_map_name_as_prefix.WithPrefixApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.mockito.Mockito.mockStatic;
+import static org.springframework.cloud.kubernetes.client.config.boostrap.stubs.ConfigMapNameAsPrefixConfigurationStub.stubData;
+
+/**
+ * @author Ryan Baxter
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = WithPrefixApp.class,
+		properties = { "spring.cloud.application.name=config-map-name-as-prefix", "config.map.name.as.prefix.stub=true",
+				"spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./config-map-name-as-prefix.yaml" })
+@AutoConfigureWebTestClient
+public class KubernetesClientConfigMapConfigDataNameAsPrefixTests extends KubernetesClientConfigMapNameAsPrefixTests {
+
+	private static MockedStatic<KubernetesClientUtils> clientUtilsMock;
+
+	@BeforeAll
+	public static void wireMock() {
+		WireMockServer server = new WireMockServer(options().dynamicPort());
+		server.start();
+		WireMock.configureFor("localhost", server.port());
+		clientUtilsMock = mockStatic(KubernetesClientUtils.class);
+		clientUtilsMock.when(KubernetesClientUtils::kubernetesApiClient)
+				.thenReturn(new ClientBuilder().setBasePath(server.baseUrl()).build());
+		stubData();
+	}
+
+	@AfterAll
+	static void teardown() {
+		clientUtilsMock.close();
+	}
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapIncludeProfileSpecificSourcesTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapIncludeProfileSpecificSourcesTests.java
@@ -21,14 +21,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.client.config.applications.include_profile_specific_sources.IncludeProfileSpecificSourcesApp;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
@@ -36,14 +30,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  *
  * @author wind57
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		classes = IncludeProfileSpecificSourcesApp.class,
-		properties = { "spring.cloud.bootstrap.name=include-profile-specific-sources",
-				"include.profile.specific.sources=true", "spring.main.cloud-platform=KUBERNETES" })
-@AutoConfigureWebTestClient
-@ActiveProfiles("dev")
-class KubernetesClientConfigMapIncludeProfileSpecificSourcesTests {
+abstract class KubernetesClientConfigMapIncludeProfileSpecificSourcesTests {
 
 	@Autowired
 	private WebTestClient webClient;

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapNameAsPrefixTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/KubernetesClientConfigMapNameAsPrefixTests.java
@@ -21,13 +21,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.client.config.applications.config_map_name_as_prefix.WithPrefixApp;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
@@ -35,12 +30,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
  *
  * @author wind57
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = WithPrefixApp.class,
-		properties = { "spring.cloud.bootstrap.name=config-map-name-as-prefix", "config.map.name.as.prefix.stub=true",
-				"spring.main.cloud-platform=KUBERNETES" })
-@AutoConfigureWebTestClient
-public class KubernetesClientConfigMapNameAsPrefixTests {
+abstract class KubernetesClientConfigMapNameAsPrefixTests {
 
 	@Autowired
 	private WebTestClient webClient;

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap/stubs/ConfigMapNameAsPrefixConfigurationStub.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap/stubs/ConfigMapNameAsPrefixConfigurationStub.java
@@ -64,7 +64,7 @@ public class ConfigMapNameAsPrefixConfigurationStub {
 		return apiClient;
 	}
 
-	private void stubData() {
+	public static void stubData() {
 		V1ConfigMap one = new V1ConfigMapBuilder()
 				.withMetadata(new V1ObjectMetaBuilder().withName("config-map-one").withNamespace("spring-k8s")
 						.withResourceVersion("1").build())

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap/stubs/IncludeProfileSpecificSourcesConfigurationStub.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap/stubs/IncludeProfileSpecificSourcesConfigurationStub.java
@@ -45,7 +45,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 @Order(0)
 @Configuration
 @ConditionalOnProperty("include.profile.specific.sources")
-class IncludeProfileSpecificSourcesConfigurationStub {
+public class IncludeProfileSpecificSourcesConfigurationStub {
 
 	@Bean
 	public WireMockServer wireMock() {
@@ -64,7 +64,7 @@ class IncludeProfileSpecificSourcesConfigurationStub {
 		return apiClient;
 	}
 
-	private void stubData() {
+	public static void stubData() {
 		V1ConfigMap one = new V1ConfigMapBuilder()
 				.withMetadata(new V1ObjectMetaBuilder().withName("config-map-one-dev").withNamespace("spring-k8s")
 						.withResourceVersion("1").build())

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesClientBootstrapConfigurationInsideK8s.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesClientBootstrapConfigurationInsideK8s.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wind57
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=abc" })
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=abc",
+				"spring.cloud.bootstrap.enabled=true" })
 class KubernetesClientBootstrapConfigurationInsideK8s {
 
 	@Autowired

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesDisabled.java
@@ -31,8 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wind57
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.enabled=false", "kubernetes.informer.enabled=false",
-				"kubernetes.manifests.enabled=false" })
+		properties = { "kubernetes.informer.enabled=false", "kubernetes.manifests.enabled=false" })
 class KubernetesDisabled {
 
 	@Autowired

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabled.java
@@ -28,7 +28,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" })
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
 class KubernetesEnabled {
 
 	@Autowired

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabledConfigDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabledConfigDisabled.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wind57
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.config.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
+		properties = { "spring.cloud.kubernetes.config.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
 class KubernetesEnabledConfigDisabled {
 
 	@Autowired

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabledOnPurpose.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabledOnPurpose.java
@@ -32,7 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
 		properties = { "spring.cloud.kubernetes.secrets.enabled=true",
-				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" })
+				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
 class KubernetesEnabledOnPurpose {
 
 	@Autowired

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabledSecretsDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/boostrap_configuration/KubernetesEnabledSecretsDisabled.java
@@ -32,7 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
 		properties = { "spring.cloud.kubernetes.secrets.enabled=false",
-				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" })
+				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
 class KubernetesEnabledSecretsDisabled {
 
 	@Autowired

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigFailFastDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigFailFastDisabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" },
+		classes = App.class)
+class BootstrapConfigFailFastDisabled extends ConfigFailFastDisabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigFailFastEnabledButRetryDisabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" },
+		classes = App.class)
+class BootstrapConfigFailFastEnabledButRetryDisabled extends ConfigFailFastEnabledButRetryDisabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigRetryDisabledButSecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigRetryDisabledButSecretsRetryEnabled.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" },
+		classes = App.class)
+class BootstrapConfigRetryDisabledButSecretsRetryEnabled extends ConfigRetryDisabledButSecretsRetryEnabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/BootstrapConfigRetryEnabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.max-attempts=5",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" },
+		classes = App.class)
+class BootstrapConfigRetryEnabled extends ConfigRetryEnabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigFailFastDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigFailFastDisabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" },
+		classes = App.class)
+class ConfigDataConfigFailFastDisabled extends ConfigFailFastDisabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigFailFastEnabledButRetryDisabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
+		classes = App.class)
+class ConfigDataConfigFailFastEnabledButRetryDisabled extends ConfigFailFastEnabledButRetryDisabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigRetryDisabledButSecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigRetryDisabledButSecretsRetryEnabled.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" },
+		classes = App.class)
+class ConfigDataConfigRetryDisabledButSecretsRetryEnabled extends ConfigRetryDisabledButSecretsRetryEnabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigDataConfigRetryEnabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.client.config.configmap_retry;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.max-attempts=5",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
+		classes = App.class)
+class ConfigDataConfigRetryEnabled extends ConfigRetryEnabled {
+
+}

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigFailFastDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigFailFastDisabled.java
@@ -28,8 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
 import org.springframework.cloud.kubernetes.client.config.KubernetesClientConfigMapPropertySourceLocator;
 import org.springframework.mock.env.MockEnvironment;
@@ -40,16 +39,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" },
-		classes = App.class)
-class ConfigFailFastDisabled {
+abstract class ConfigFailFastDisabled {
 
 	private static final String API = "/api/v1/namespaces/default/configmaps";
 
@@ -86,12 +83,12 @@ class ConfigFailFastDisabled {
 		stubConfigMapAndSecretsDefaults();
 	}
 
-	@SpyBean
+	@Autowired
 	private KubernetesClientConfigMapPropertySourceLocator propertySourceLocator;
 
 	@Test
 	void locateShouldNotRetry() {
-
+		propertySourceLocator = spy(propertySourceLocator);
 		stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
 
 		Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/configmap_retry/ConfigFailFastEnabledButRetryDisabled.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
 import org.springframework.cloud.kubernetes.client.config.KubernetesClientConfigMapPropertySourceLocator;
 import org.springframework.context.ApplicationContext;
@@ -43,18 +41,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default",
-				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
-				"spring.main.cloud-platform=KUBERNETES" },
-		classes = App.class)
-class ConfigFailFastEnabledButRetryDisabled {
+abstract class ConfigFailFastEnabledButRetryDisabled {
 
 	private static final String API = "/api/v1/namespaces/default/configmaps";
 
@@ -91,7 +85,7 @@ class ConfigFailFastEnabledButRetryDisabled {
 		stubConfigMapAndSecretsDefaults();
 	}
 
-	@SpyBean
+	@Autowired
 	private KubernetesClientConfigMapPropertySourceLocator propertySourceLocator;
 
 	@Autowired
@@ -99,7 +93,7 @@ class ConfigFailFastEnabledButRetryDisabled {
 
 	@Test
 	void locateShouldFailWithoutRetrying() {
-
+		propertySourceLocator = spy(propertySourceLocator);
 		stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
 
 		assertThat(context.containsBean("kubernetesConfigRetryInterceptor")).isFalse();

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/secrets_retry/SecretsFailFastDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/secrets_retry/SecretsFailFastDisabled.java
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
 import org.springframework.cloud.kubernetes.client.config.KubernetesClientSecretsPropertySourceLocator;
 import org.springframework.mock.env.MockEnvironment;
@@ -40,6 +40,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -49,7 +50,7 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = { "spring.cloud.kubernetes.client.namespace=default",
 				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
-				"spring.main.cloud-platform=KUBERNETES" },
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
 		classes = Application.class)
 class SecretsFailFastDisabled {
 
@@ -88,12 +89,12 @@ class SecretsFailFastDisabled {
 		stubConfigMapAndSecretsDefaults();
 	}
 
-	@SpyBean
-	private KubernetesClientSecretsPropertySourceLocator propertySourceLocator;
+	@Autowired
+	private KubernetesClientSecretsPropertySourceLocator psl;
 
 	@Test
 	void locateShouldNotRetry() {
-
+		KubernetesClientSecretsPropertySourceLocator propertySourceLocator = spy(psl);
 		stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
 
 		Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/secrets_retry/SecretsFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/secrets_retry/SecretsFailFastEnabledButRetryDisabled.java
@@ -30,7 +30,6 @@ import org.mockito.MockedStatic;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
 import org.springframework.cloud.kubernetes.client.config.KubernetesClientSecretsPropertySourceLocator;
 import org.springframework.context.ApplicationContext;
@@ -44,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.verify;
 		properties = { "spring.cloud.kubernetes.client.namespace=default",
 				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
 				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
-				"spring.main.cloud-platform=KUBERNETES" },
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
 		classes = Application.class)
 class SecretsFailFastEnabledButRetryDisabled {
 
@@ -97,15 +97,15 @@ class SecretsFailFastEnabledButRetryDisabled {
 		stubConfigMapAndSecretsDefaults();
 	}
 
-	@SpyBean
-	private KubernetesClientSecretsPropertySourceLocator propertySourceLocator;
+	@Autowired
+	private KubernetesClientSecretsPropertySourceLocator psl;
 
 	@Autowired
 	private ApplicationContext context;
 
 	@Test
 	void locateShouldFailWithoutRetrying() {
-
+		KubernetesClientSecretsPropertySourceLocator propertySourceLocator = spy(psl);
 		stubFor(get(API).willReturn(aResponse().withStatus(500).withBody("Internal Server Error")));
 
 		assertThat(context.containsBean("kubernetesSecretsRetryInterceptor")).isFalse();

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/KubernetesClientProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/KubernetesClientProperties.java
@@ -20,13 +20,20 @@ import java.time.Duration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import static org.springframework.cloud.kubernetes.commons.KubernetesClientProperties.PREFIX;
+
 /**
  * Kubernetes client properties.
  *
  * @author Ioannis Canellos
  */
-@ConfigurationProperties("spring.cloud.kubernetes.client")
+@ConfigurationProperties(PREFIX)
 public class KubernetesClientProperties {
+
+	/**
+	 * Configuration properties prefix.
+	 */
+	public static final String PREFIX = "spring.cloud.kubernetes.client";
 
 	/**
 	 * Default user-agent for kubernetes client.

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/AbstractConfigProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/AbstractConfigProperties.java
@@ -121,6 +121,8 @@ public abstract class AbstractConfigProperties {
 		 */
 		private int maxAttempts = 6;
 
+		private boolean enabled = true;
+
 		public long getInitialInterval() {
 			return this.initialInterval;
 		}
@@ -151,6 +153,14 @@ public abstract class AbstractConfigProperties {
 
 		public void setMaxAttempts(int maxAttempts) {
 			this.maxAttempts = maxAttempts;
+		}
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
 		}
 
 	}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigDataRetryableConfigMapPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigDataRetryableConfigMapPropertySourceLocator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.util.Collection;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * ConfigMapPropertySourceLocator for when retry is enabled.
+ *
+ * @author Ryan Baxter
+ */
+public class ConfigDataRetryableConfigMapPropertySourceLocator extends ConfigMapPropertySourceLocator {
+
+	private RetryTemplate retryTemplate;
+
+	private ConfigMapPropertySourceLocator configMapPropertySourceLocator;
+
+	public ConfigDataRetryableConfigMapPropertySourceLocator(
+			ConfigMapPropertySourceLocator configMapPropertySourceLocator, ConfigMapConfigProperties properties) {
+		super(properties);
+		this.configMapPropertySourceLocator = configMapPropertySourceLocator;
+		this.retryTemplate = RetryTemplate.builder().maxAttempts(properties.getRetry().getMaxAttempts())
+				.exponentialBackoff(properties.getRetry().getInitialInterval(), properties.getRetry().getMultiplier(),
+						properties.getRetry().getMaxInterval())
+				.build();
+	}
+
+	@Override
+	protected MapPropertySource getMapPropertySource(NormalizedSource normalizedSource,
+			ConfigurableEnvironment environment) {
+		return configMapPropertySourceLocator.getMapPropertySource(normalizedSource, environment);
+	}
+
+	@Override
+	public PropertySource<?> locate(Environment environment) {
+		return retryTemplate.execute(retryContext -> configMapPropertySourceLocator.locate(environment));
+	}
+
+	@Override
+	public Collection<PropertySource<?>> locateCollection(Environment environment) {
+		return retryTemplate.execute(retryContext -> configMapPropertySourceLocator.locateCollection(environment));
+	}
+
+	public void setConfigMapPropertySourceLocator(ConfigMapPropertySourceLocator configMapPropertySourceLocator) {
+		this.configMapPropertySourceLocator = configMapPropertySourceLocator;
+	}
+
+	public ConfigMapPropertySourceLocator getConfigMapPropertySourceLocator() {
+		return configMapPropertySourceLocator;
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigDataRetryableSecretsPropertySourceLocator.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/ConfigDataRetryableSecretsPropertySourceLocator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.util.Collection;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * SecretsPropertySourceLocator for when retry is enabled.
+ *
+ * @author Ryan Baxter
+ */
+public class ConfigDataRetryableSecretsPropertySourceLocator extends SecretsPropertySourceLocator {
+
+	private RetryTemplate retryTemplate;
+
+	private SecretsPropertySourceLocator secretsPropertySourceLocator;
+
+	public ConfigDataRetryableSecretsPropertySourceLocator(SecretsPropertySourceLocator propertySourceLocator,
+			SecretsConfigProperties secretsConfigProperties) {
+		super(secretsConfigProperties);
+		this.secretsPropertySourceLocator = propertySourceLocator;
+		this.retryTemplate = RetryTemplate.builder().maxAttempts(properties.getRetry().getMaxAttempts())
+				.exponentialBackoff(properties.getRetry().getInitialInterval(), properties.getRetry().getMultiplier(),
+						properties.getRetry().getMaxInterval())
+				.build();
+	}
+
+	@Override
+	public PropertySource<?> locate(Environment environment) {
+		return retryTemplate.execute(retryContext -> secretsPropertySourceLocator.locate(environment));
+	}
+
+	@Override
+	public Collection<PropertySource<?>> locateCollection(Environment environment) {
+		return retryTemplate.execute(retryContext -> secretsPropertySourceLocator.locateCollection(environment));
+	}
+
+	@Override
+	protected MapPropertySource getPropertySource(ConfigurableEnvironment environment,
+			NormalizedSource normalizedSource) {
+		return this.secretsPropertySourceLocator.getPropertySource(environment, normalizedSource);
+	}
+
+	public SecretsPropertySourceLocator getSecretsPropertySourceLocator() {
+		return secretsPropertySourceLocator;
+	}
+
+	public void setSecretsPropertySourceLocator(SecretsPropertySourceLocator secretsPropertySourceLocator) {
+		this.secretsPropertySourceLocator = secretsPropertySourceLocator;
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesBootstrapConfiguration.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesBootstrapConfiguration.java
@@ -46,9 +46,9 @@ public class KubernetesBootstrapConfiguration {
 	@Configuration(proxyBeanMethods = false)
 	@EnableRetry(proxyTargetClass = true)
 	@Import(AopAutoConfiguration.class)
-	static class RetryConfiguration {
+	public static class RetryConfiguration {
 
-		private static RetryOperationsInterceptor retryOperationsInterceptor(
+		public static RetryOperationsInterceptor retryOperationsInterceptor(
 				AbstractConfigProperties.RetryProperties retryProperties) {
 			return RetryInterceptorBuilder.stateless().backOffOptions(retryProperties.getInitialInterval(),
 					retryProperties.getMultiplier(), retryProperties.getMaxInterval())

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLoader.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLoader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.config.ConfigData;
 import org.springframework.boot.context.config.ConfigData.Option;
 import org.springframework.boot.context.config.ConfigDataLoader;
@@ -37,10 +38,16 @@ public class KubernetesConfigDataLoader implements ConfigDataLoader<KubernetesCo
 	public ConfigData load(ConfigDataLoaderContext context, KubernetesConfigDataResource resource)
 			throws IOException, ConfigDataResourceNotFoundException {
 		List<PropertySource<?>> propertySources = new ArrayList<>();
-		ConfigMapPropertySourceLocator configMapPropertySourceLocator = context.getBootstrapContext()
-				.getOrElse(ConfigMapPropertySourceLocator.class, null);
-		SecretsPropertySourceLocator secretsPropertySourceLocator = context.getBootstrapContext()
-				.getOrElse(SecretsPropertySourceLocator.class, null);
+		ConfigurableBootstrapContext bootstrapContext = context.getBootstrapContext();
+		ConfigMapPropertySourceLocator configMapPropertySourceLocator = null;
+		SecretsPropertySourceLocator secretsPropertySourceLocator = null;
+		if (bootstrapContext.isRegistered(ConfigMapPropertySourceLocator.class)) {
+			configMapPropertySourceLocator = bootstrapContext.getOrElse(ConfigMapPropertySourceLocator.class, null);
+		}
+		if (bootstrapContext.isRegistered(SecretsPropertySourceLocator.class)) {
+			secretsPropertySourceLocator = context.getBootstrapContext().getOrElse(SecretsPropertySourceLocator.class,
+					null);
+		}
 
 		if (configMapPropertySourceLocator != null) {
 			propertySources.add(configMapPropertySourceLocator.locate(resource.getEnvironment()));

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLoader.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLoader.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.config.ConfigData;
+import org.springframework.boot.context.config.ConfigData.Option;
+import org.springframework.boot.context.config.ConfigDataLoader;
+import org.springframework.boot.context.config.ConfigDataLoaderContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * @author Ryan Baxter
+ */
+public class KubernetesConfigDataLoader implements ConfigDataLoader<KubernetesConfigDataResource>, Ordered {
+
+	@Override
+	public ConfigData load(ConfigDataLoaderContext context, KubernetesConfigDataResource resource)
+			throws IOException, ConfigDataResourceNotFoundException {
+		List<PropertySource<?>> propertySources = new ArrayList<>();
+		ConfigMapPropertySourceLocator configMapPropertySourceLocator = context.getBootstrapContext()
+				.getOrElse(ConfigMapPropertySourceLocator.class, null);
+		SecretsPropertySourceLocator secretsPropertySourceLocator = context.getBootstrapContext()
+				.getOrElse(SecretsPropertySourceLocator.class, null);
+
+		if (configMapPropertySourceLocator != null) {
+			propertySources.add(configMapPropertySourceLocator.locate(resource.getEnvironment()));
+		}
+		if (secretsPropertySourceLocator != null) {
+			propertySources.add(secretsPropertySourceLocator.locate(resource.getEnvironment()));
+		}
+		// boot 2.4.5+
+		return new ConfigData(propertySources, propertySource -> {
+			String propertySourceName = propertySource.getName();
+			List<Option> options = new ArrayList<>();
+			options.add(Option.IGNORE_IMPORTS);
+			options.add(Option.IGNORE_PROFILES);
+			// TODO: the profile is now available on the backend
+			// in a future minor, add the profile associated with a
+			// PropertySource see
+			// https://github.com/spring-cloud/spring-cloud-config/issues/1874
+			for (String profile : resource.getAcceptedProfiles()) {
+				// TODO: switch to match
+				// , is used as a profile-separator for property sources
+				// from vault
+				// - is the default profile-separator for property sources
+				if (propertySourceName.matches(".*[-,]" + profile + ".*")) {
+					// // TODO: switch to Options.with() when implemented
+					options.add(Option.PROFILE_SPECIFIC);
+				}
+			}
+			return ConfigData.Options.of(options.toArray(new Option[0]));
+		});
+
+	}
+
+	@Override
+	public int getOrder() {
+		return -1;
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
@@ -193,8 +193,8 @@ public abstract class KubernetesConfigDataLocationResolver
 		SecretsConfigProperties secretsProperties = binder
 				.bind(SecretsConfigProperties.PREFIX, SecretsConfigProperties.class)
 				.orElseGet(SecretsConfigProperties::new);
-		return new PropertyHolder(kubernetesClientProperties, configMapConfigProperties,
-				secretsProperties, applicationName);
+		return new PropertyHolder(kubernetesClientProperties, configMapConfigProperties, secretsProperties,
+				applicationName);
 
 	}
 

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
@@ -39,7 +39,6 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
 import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
-import org.springframework.context.EnvironmentAware;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
@@ -52,7 +51,7 @@ import org.springframework.util.ClassUtils;
  * @author Ryan Baxter
  */
 public abstract class KubernetesConfigDataLocationResolver
-		implements ConfigDataLocationResolver<KubernetesConfigDataResource>, Ordered, EnvironmentAware {
+		implements ConfigDataLocationResolver<KubernetesConfigDataResource>, Ordered {
 
 	static final boolean RETRY_IS_PRESENT = ClassUtils.isPresent("org.springframework.retry.annotation.Retryable",
 			null);
@@ -77,10 +76,9 @@ public abstract class KubernetesConfigDataLocationResolver
 		if (!location.hasPrefix(getPrefix())) {
 			return false;
 		}
-		boolean enabled = context.getBinder().bind("spring.cloud.kubernetes.enabled", Boolean.class).orElse(true);
 
 		return (CloudPlatform.KUBERNETES.isEnforced(context.getBinder())
-				|| CloudPlatform.KUBERNETES.isDetected(new StandardEnvironment())) && enabled;
+				|| CloudPlatform.KUBERNETES.isDetected(new StandardEnvironment()));
 	}
 
 	@Override
@@ -198,11 +196,6 @@ public abstract class KubernetesConfigDataLocationResolver
 		PropertyHolder holder = new PropertyHolder(kubernetesClientProperties, configMapConfigProperties,
 				secretsProperties, applicationName);
 		return holder;
-	}
-
-	@Override
-	public void setEnvironment(Environment environment) {
-
 	}
 
 	protected record PropertyHolder(KubernetesClientProperties kubernetesClientProperties,

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
@@ -37,6 +37,7 @@ import org.springframework.boot.context.config.Profiles;
 import org.springframework.boot.context.properties.bind.BindHandler;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
 import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
 import org.springframework.core.Ordered;
@@ -63,8 +64,8 @@ public abstract class KubernetesConfigDataLocationResolver
 
 	private final Log log;
 
-	public KubernetesConfigDataLocationResolver(Log log) {
-		this.log = log;
+	public KubernetesConfigDataLocationResolver(DeferredLogFactory factory) {
+		this.log = factory.getLog(KubernetesConfigDataLocationResolver.class);
 	}
 
 	protected String getPrefix() {

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataLocationResolver.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
+import org.springframework.boot.ConfigurableBootstrapContext;
+import org.springframework.boot.cloud.CloudPlatform;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationNotFoundException;
+import org.springframework.boot.context.config.ConfigDataLocationResolver;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.ConfigDataResourceNotFoundException;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.context.properties.bind.BindHandler;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Ryan Baxter
+ */
+public abstract class KubernetesConfigDataLocationResolver
+		implements ConfigDataLocationResolver<KubernetesConfigDataResource>, Ordered {
+
+	static final boolean RETRY_IS_PRESENT = ClassUtils.isPresent("org.springframework.retry.annotation.Retryable",
+			null);
+
+	/**
+	 * Prefix for Config Server imports.
+	 */
+	public static final String PREFIX = "kubernetes:";
+
+	private final Log log;
+
+	public KubernetesConfigDataLocationResolver(Log log) {
+		this.log = log;
+	}
+
+	protected String getPrefix() {
+		return PREFIX;
+	}
+
+	@Override
+	public boolean isResolvable(ConfigDataLocationResolverContext context, ConfigDataLocation location) {
+		if (!location.hasPrefix(getPrefix())) {
+			return false;
+		}
+		// TODO Could we use KubernetesClientPodUtils.isInsideKubernetes instead?
+		CloudPlatform platformProperty = context.getBinder().bind("spring.main.cloud-platform", CloudPlatform.class)
+				.orElse(CloudPlatform.NONE);
+		String host = context.getBinder().bind("kubernetes.service.host", String.class).orElse("");
+		String port = context.getBinder().bind("kubernetes.service.port", String.class).orElse("");
+		boolean enabled = context.getBinder().bind("spring.cloud.kubernetes.enabled", Boolean.class).orElse(true);
+
+		return (platformProperty.equals(CloudPlatform.KUBERNETES)
+				|| (StringUtils.hasText(host) && StringUtils.hasText(port))) && enabled;
+	}
+
+	@Override
+	public List<KubernetesConfigDataResource> resolve(ConfigDataLocationResolverContext context,
+			ConfigDataLocation location)
+			throws ConfigDataLocationNotFoundException, ConfigDataResourceNotFoundException {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<KubernetesConfigDataResource> resolveProfileSpecific(ConfigDataLocationResolverContext resolverContext,
+			ConfigDataLocation location, Profiles profiles) throws ConfigDataLocationNotFoundException {
+		String uris = location.getNonPrefixedValue(getPrefix());
+		PropertyHolder propertyHolder = loadProperties(resolverContext, uris);
+		KubernetesClientProperties properties = propertyHolder.kubernetesClientProperties;
+		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapProperties;
+		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties;
+
+		ConfigurableBootstrapContext bootstrapContext = resolverContext.getBootstrapContext();
+		bootstrapContext.registerIfAbsent(KubernetesClientProperties.class, InstanceSupplier.of(properties));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+				"configDataKubernetesClientProperties",
+				event.getBootstrapContext().get(KubernetesClientProperties.class)));
+
+		bootstrapContext.registerIfAbsent(ConfigMapConfigProperties.class, InstanceSupplier.of(configMapProperties));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+				"configDataConfigMapConfigProperties",
+				event.getBootstrapContext().get(ConfigMapConfigProperties.class)));
+
+		bootstrapContext.registerIfAbsent(SecretsConfigProperties.class, InstanceSupplier.of(secretsProperties));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+				"configDataSecretsConfigProperties", event.getBootstrapContext().get(SecretsConfigProperties.class)));
+
+		HashMap<String, Object> kubernetesConfigData = new HashMap<>();
+		kubernetesConfigData.put("spring.cloud.kubernetes.client.namespace", properties.getNamespace());
+		if (propertyHolder.applicationName != null) {
+			// If its null it means sprig.application.name was not set so don't add it to
+			// the property source
+			kubernetesConfigData.put("spring.application.name", propertyHolder.applicationName);
+		}
+		PropertySource<Map<String, Object>> propertySource = new MapPropertySource("kubernetesConfigData",
+				kubernetesConfigData);
+		ConfigurableEnvironment environment = new StandardEnvironment();
+		environment.getPropertySources().addLast(propertySource);
+		environment.setActiveProfiles(profiles.getAccepted().toArray(new String[profiles.getAccepted().size()]));
+		KubernetesNamespaceProvider namespaceProvider = kubernetesNamespaceProvider(environment);
+
+		registerBeans(resolverContext, location, profiles, propertyHolder, namespaceProvider);
+
+		KubernetesConfigDataResource resource = new KubernetesConfigDataResource(properties, configMapProperties,
+				secretsProperties, location.isOptional(), profiles, environment);
+		resource.setLog(log);
+
+		List<KubernetesConfigDataResource> locations = new ArrayList<>();
+		locations.add(resource);
+
+		return locations;
+	}
+
+	protected abstract void registerBeans(ConfigDataLocationResolverContext resolverContext,
+			ConfigDataLocation location, Profiles profiles, PropertyHolder propertyHolder,
+			KubernetesNamespaceProvider namespaceProvider);
+
+	protected boolean isRetryEnabled(ConfigMapConfigProperties configMapProperties,
+			SecretsConfigProperties secretsProperties) {
+		return isRetryEnabledForConfigMap(configMapProperties) || isRetryEnabledForSecrets(secretsProperties);
+	}
+
+	protected boolean isRetryEnabledForConfigMap(ConfigMapConfigProperties configMapProperties) {
+		return RETRY_IS_PRESENT && configMapProperties.getRetry().isEnabled() && configMapProperties.isFailFast();
+	}
+
+	protected boolean isRetryEnabledForSecrets(SecretsConfigProperties secretsProperties) {
+		return RETRY_IS_PRESENT && secretsProperties.getRetry().isEnabled() && secretsProperties.isFailFast();
+	}
+
+	protected KubernetesNamespaceProvider kubernetesNamespaceProvider(Environment environment) {
+		return new KubernetesNamespaceProvider(environment);
+	}
+
+	@Override
+	public int getOrder() {
+		return -1;
+	}
+
+	private BindHandler getBindHandler(ConfigDataLocationResolverContext context) {
+		return context.getBootstrapContext().getOrElse(BindHandler.class, null);
+	}
+
+	protected PropertyHolder loadProperties(ConfigDataLocationResolverContext context, String uris) {
+		Binder binder = context.getBinder();
+		BindHandler bindHandler = getBindHandler(context);
+		String applicationName = binder.bind("spring.application.name", String.class).orElse(null);
+		String namespace = binder.bind("spring.cloud.kubernetes.client.namespace", String.class)
+				.orElse(binder.bind("kubernetes.namespace", String.class).orElse(""));
+		boolean configMapEnabled = binder.bind("spring.cloud.kubernetes.config.enabled", Boolean.class).orElse(true);
+		boolean secretsEnabled = binder.bind("spring.cloud.kubernetes.secrets.enabled", Boolean.class).orElse(true);
+
+		KubernetesClientProperties kubernetesClientProperties;
+		if (context.getBootstrapContext().isRegistered(KubernetesClientProperties.class)) {
+			kubernetesClientProperties = new KubernetesClientProperties();
+			BeanUtils.copyProperties(context.getBootstrapContext().get(KubernetesClientProperties.class),
+					kubernetesClientProperties);
+		}
+		else {
+			kubernetesClientProperties = binder
+					.bind(KubernetesClientProperties.PREFIX, Bindable.of(KubernetesClientProperties.class), bindHandler)
+					.orElseGet(KubernetesClientProperties::new);
+		}
+		kubernetesClientProperties.setNamespace(namespace);
+
+		PropertyHolder holder = new PropertyHolder();
+		holder.kubernetesClientProperties = kubernetesClientProperties;
+		// bind retry, override later
+		holder.configMapProperties = binder.bind(ConfigMapConfigProperties.PREFIX, ConfigMapConfigProperties.class)
+				.orElseGet(ConfigMapConfigProperties::new);
+		holder.secretsProperties = binder.bind(SecretsConfigProperties.PREFIX, SecretsConfigProperties.class)
+				.orElseGet(SecretsConfigProperties::new);
+		holder.applicationName = applicationName;
+		return holder;
+	}
+
+	protected static class PropertyHolder {
+
+		public KubernetesClientProperties kubernetesClientProperties;
+
+		public ConfigMapConfigProperties configMapProperties;
+
+		public SecretsConfigProperties secretsProperties;
+
+		public String applicationName;
+
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataResource.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataResource.java
@@ -108,13 +108,15 @@ public class KubernetesConfigDataResource extends ConfigDataResource {
 		}
 		KubernetesConfigDataResource that = (KubernetesConfigDataResource) o;
 		return Objects.equals(this.properties, that.properties) && Objects.equals(this.optional, that.optional)
-				&& Objects.equals(this.profiles, that.profiles) && Objects.equals(this.configMapProperties, that.configMapProperties)
-			&& Objects.equals(this.secretsConfigProperties, that.secretsConfigProperties);
+				&& Objects.equals(this.profiles, that.profiles)
+				&& Objects.equals(this.configMapProperties, that.configMapProperties)
+				&& Objects.equals(this.secretsConfigProperties, that.secretsConfigProperties);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.properties, this.optional, this.profiles, configMapProperties, secretsConfigProperties);
+		return Objects.hash(this.properties, this.optional, this.profiles, configMapProperties,
+				secretsConfigProperties);
 	}
 
 	@Override

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataResource.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/config/KubernetesConfigDataResource.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.commons.config;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+
+import org.springframework.boot.context.config.ConfigDataResource;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Ryan Baxter
+ */
+public class KubernetesConfigDataResource extends ConfigDataResource {
+
+	private final KubernetesClientProperties properties;
+
+	private final ConfigMapConfigProperties configMapProperties;
+
+	private final SecretsConfigProperties secretsConfigProperties;
+
+	private final boolean optional;
+
+	private final Profiles profiles;
+
+	private Log log;
+
+	private Environment environment;
+
+	public KubernetesConfigDataResource(KubernetesClientProperties properties,
+			ConfigMapConfigProperties configMapProperties, SecretsConfigProperties secretsConfigProperties,
+			boolean optional, Profiles profiles, Environment environment) {
+		this.properties = properties;
+		this.configMapProperties = configMapProperties;
+		this.secretsConfigProperties = secretsConfigProperties;
+		this.optional = optional;
+		this.profiles = profiles;
+		this.environment = environment;
+	}
+
+	public KubernetesClientProperties getProperties() {
+		return this.properties;
+	}
+
+	public ConfigMapConfigProperties getConfigMapProperties() {
+		return configMapProperties;
+	}
+
+	public SecretsConfigProperties getSecretsConfigProperties() {
+		return secretsConfigProperties;
+	}
+
+	public boolean isOptional() {
+		return this.optional;
+	}
+
+	public String getProfiles() {
+		return StringUtils.collectionToCommaDelimitedString(getAcceptedProfiles());
+	}
+
+	List<String> getAcceptedProfiles() {
+		return this.profiles.getAccepted();
+	}
+
+	public void setLog(Log log) {
+		this.log = log;
+	}
+
+	public Log getLog() {
+		return this.log;
+	}
+
+	public Environment getEnvironment() {
+		return environment;
+	}
+
+	public void setEnvironment(Environment environment) {
+		this.environment = environment;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		KubernetesConfigDataResource that = (KubernetesConfigDataResource) o;
+		return Objects.equals(this.properties, that.properties) && Objects.equals(this.optional, that.optional)
+				&& Objects.equals(this.profiles, that.profiles) && Objects.equals(this.configMapProperties, that.configMapProperties)
+			&& Objects.equals(this.secretsConfigProperties, that.secretsConfigProperties);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.properties, this.optional, this.profiles, configMapProperties, secretsConfigProperties);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this).append("optional", optional).append("profiles", profiles.getAccepted())
+				.toString();
+
+	}
+
+}

--- a/spring-cloud-kubernetes-commons/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-kubernetes-commons/src/main/resources/META-INF/spring.factories
@@ -3,3 +3,7 @@ org.springframework.cloud.kubernetes.commons.KubernetesCommonsAutoConfiguration,
 org.springframework.cloud.kubernetes.commons.config.reload.ConfigReloadAutoConfiguration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.kubernetes.commons.config.KubernetesBootstrapConfiguration
+
+# ConfigData Loaders
+org.springframework.boot.context.config.ConfigDataLoader=\
+org.springframework.cloud.kubernetes.commons.config.KubernetesConfigDataLoader

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/pom.xml
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/pom.xml
@@ -35,11 +35,23 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<!-- in favor of mockito-inline -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+				</exclusion>
+			</exclusions>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock-jre8-standalone</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/BootstrapConfigServerIntegrationTest.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/BootstrapConfigServerIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.configserver;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Ryan Baxter
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=default",
+				"spring.profiles.include=kubernetes", "spring.cloud.kubernetes.secrets.enableApi=true", "debug=true",
+				"spring.cloud.bootstrap.enabled=true" },
+		classes = { KubernetesConfigServerApplication.class })
+public class BootstrapConfigServerIntegrationTest extends ConfigServerIntegrationTest {
+
+}

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigDataConfigServerIntegrationTest.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigDataConfigServerIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.configserver;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.kubernetes.client.util.ClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.mockito.MockedStatic;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * @author Ryan Baxter
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=default",
+				"spring.profiles.include=kubernetes", "spring.cloud.kubernetes.secrets.enableApi=true", "debug=true",
+				"spring.config.import=kubernetes:" },
+		classes = { KubernetesConfigServerApplication.class })
+public class ConfigDataConfigServerIntegrationTest extends ConfigServerIntegrationTest {
+
+	private static WireMockServer wireMockServer;
+
+	private static MockedStatic<KubernetesClientUtils> clientUtilsMock;
+
+	@BeforeAll
+	static void setup() {
+		wireMockServer = new WireMockServer(options().dynamicPort());
+		wireMockServer.start();
+		WireMock.configureFor(wireMockServer.port());
+
+		clientUtilsMock = mockStatic(KubernetesClientUtils.class);
+		clientUtilsMock.when(KubernetesClientUtils::kubernetesApiClient)
+				.thenReturn(new ClientBuilder().setBasePath(wireMockServer.baseUrl()).build());
+	}
+
+	@AfterAll
+	static void teardown() {
+		wireMockServer.stop();
+		clientUtilsMock.close();
+	}
+
+	@AfterEach
+	void afterEach() {
+		WireMock.reset();
+	}
+
+}

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesDisabled.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ryan Baxter
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		properties = { "spring.profiles.include=kubernetes,kubernetesdisabled", "spring.cloud.kubernetes.enabled=false",
+		properties = { "spring.profiles.include=kubernetes,kubernetesdisabled",
 				"debug=true" },
 		classes = { KubernetesConfigServerApplication.class, MockConfig.class })
 class ConfigServerAutoConfigurationKubernetesDisabled {

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesDisabled.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ryan Baxter
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		properties = { "spring.profiles.include=kubernetes,kubernetesdisabled",
-				"debug=true" },
+		properties = { "spring.profiles.include=kubernetes,kubernetesdisabled", "debug=true" },
 		classes = { KubernetesConfigServerApplication.class, MockConfig.class })
 class ConfigServerAutoConfigurationKubernetesDisabled {
 

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesProfileMissing.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesProfileMissing.java
@@ -29,8 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		classes = { KubernetesConfigServerApplication.class, MockConfig.class },
-		properties = {"spring.profiles.include=kubernetes,kubernetesdisabled",
-				"debug=true" })
+		properties = { "spring.profiles.include=kubernetes,kubernetesdisabled", "debug=true" })
 class ConfigServerAutoConfigurationKubernetesProfileMissing {
 
 	@Autowired

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesProfileMissing.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerAutoConfigurationKubernetesProfileMissing.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		classes = { KubernetesConfigServerApplication.class, MockConfig.class },
-		properties = { "spring.cloud.kubernetes.enabled=false", "spring.profiles.include=kubernetes,kubernetesdisabled",
+		properties = {"spring.profiles.include=kubernetes,kubernetesdisabled",
 				"debug=true" })
 class ConfigServerAutoConfigurationKubernetesProfileMissing {
 

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerIntegrationTest.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/ConfigServerIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.config.environment.Environment;
 
@@ -41,11 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Ryan Baxter
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=default",
-				"spring.profiles.include=kubernetes", "spring.cloud.kubernetes.secrets.enableApi=true", "debug=true" },
-		classes = { KubernetesConfigServerApplication.class })
-public class ConfigServerIntegrationTest {
+abstract class ConfigServerIntegrationTest {
 
 	@Autowired
 	private TestRestTemplate testRestTemplate;

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configuration-watcher/src/main/resources/application.yml
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configuration-watcher/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: "kubernetes:"
   application:
     name: spring-cloud-kubernetes-configuration-watcher
   cloud:

--- a/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/leader-role.yml
+++ b/spring-cloud-kubernetes-examples/kubernetes-leader-election-example/leader-role.yml
@@ -10,6 +10,16 @@ rules:
   - ""
   resources:
   - pods
+  verbs:
+  - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
-  - '*'
+  - watch
+  - get
+  - update
+  # resourceNames:
+  #   - <config-map name>

--- a/spring-cloud-kubernetes-fabric8-config/pom.xml
+++ b/spring-cloud-kubernetes-fabric8-config/pom.xml
@@ -57,10 +57,6 @@
 
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-bootstrap</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-commons</artifactId>
 		</dependency>
 		<dependency>

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8BootstrapConfiguration.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8BootstrapConfiguration.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesConfigEnabled;
 import org.springframework.cloud.kubernetes.commons.ConditionalOnKubernetesSecretsEnabled;
@@ -49,6 +50,7 @@ import org.springframework.core.env.Environment;
 @ConditionalOnClass({ ConfigMap.class, Secret.class })
 @AutoConfigureAfter(KubernetesBootstrapConfiguration.class)
 @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
+@ConditionalOnProperty(value = "spring.cloud.bootstrap.enabled", havingValue = "true")
 public class Fabric8BootstrapConfiguration {
 
 	@Bean

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigDataLocationResolver.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.kubernetes.fabric8.config;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.apache.commons.logging.Log;
 
 import org.springframework.boot.BootstrapRegistry;
 import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
@@ -26,6 +25,7 @@ import org.springframework.boot.ConfigurableBootstrapContext;
 import org.springframework.boot.context.config.ConfigDataLocation;
 import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
 import org.springframework.boot.context.config.Profiles;
+import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
 import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
 import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableConfigMapPropertySourceLocator;
@@ -43,8 +43,8 @@ import org.springframework.core.env.Environment;
  */
 public class Fabric8ConfigDataLocationResolver extends KubernetesConfigDataLocationResolver {
 
-	public Fabric8ConfigDataLocationResolver(Log log) {
-		super(log);
+	public Fabric8ConfigDataLocationResolver(DeferredLogFactory factory) {
+		super(factory);
 	}
 
 	@Override

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigDataLocationResolver.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.commons.logging.Log;
+
+import org.springframework.boot.BootstrapRegistry;
+import org.springframework.boot.BootstrapRegistry.InstanceSupplier;
+import org.springframework.boot.ConfigurableBootstrapContext;
+import org.springframework.boot.context.config.ConfigDataLocation;
+import org.springframework.boot.context.config.ConfigDataLocationResolverContext;
+import org.springframework.boot.context.config.Profiles;
+import org.springframework.cloud.kubernetes.commons.KubernetesClientProperties;
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableSecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.ConfigMapConfigProperties;
+import org.springframework.cloud.kubernetes.commons.config.ConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.KubernetesConfigDataLocationResolver;
+import org.springframework.cloud.kubernetes.commons.config.SecretsConfigProperties;
+import org.springframework.cloud.kubernetes.commons.config.SecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.fabric8.Fabric8AutoConfiguration;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Ryan Baxter
+ */
+public class Fabric8ConfigDataLocationResolver extends KubernetesConfigDataLocationResolver {
+
+	public Fabric8ConfigDataLocationResolver(Log log) {
+		super(log);
+	}
+
+	@Override
+	protected void registerBeans(ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location,
+			Profiles profiles, KubernetesConfigDataLocationResolver.PropertyHolder propertyHolder,
+			KubernetesNamespaceProvider namespaceProvider) {
+		String uris = location.getNonPrefixedValue(getPrefix());
+		KubernetesClientProperties properties = propertyHolder.kubernetesClientProperties;
+		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapProperties;
+		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties;
+
+		ConfigurableBootstrapContext bootstrapContext = resolverContext.getBootstrapContext();
+		Config config = config(properties);
+		bootstrapContext.registerIfAbsent(Config.class, InstanceSupplier.of(config));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+				.registerSingleton("fabric8Config", event.getBootstrapContext().get(Config.class)));
+
+		KubernetesClient kubernetesClient = kubernetesClient(config);
+		bootstrapContext.registerIfAbsent(KubernetesClient.class,
+				BootstrapRegistry.InstanceSupplier.of(kubernetesClient));
+		bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+				.registerSingleton("configKubernetesClient", event.getBootstrapContext().get(KubernetesClient.class)));
+
+		if (isRetryEnabled(configMapProperties, secretsProperties)) {
+			registerRetryBeans(configMapProperties, secretsProperties, bootstrapContext, kubernetesClient,
+					namespaceProvider);
+		}
+		else {
+			if (configMapProperties.isEnabled()) {
+				Fabric8ConfigMapPropertySourceLocator configMapPropertySourceLocator = new Fabric8ConfigMapPropertySourceLocator(
+						kubernetesClient, configMapProperties, namespaceProvider);
+				bootstrapContext.registerIfAbsent(ConfigMapPropertySourceLocator.class,
+						InstanceSupplier.of(configMapPropertySourceLocator));
+				bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+						.registerSingleton("configDataConfigMapPropertySourceLocator",
+								event.getBootstrapContext().get(ConfigMapPropertySourceLocator.class)));
+			}
+			if (secretsProperties.isEnabled()) {
+				Fabric8SecretsPropertySourceLocator secretsPropertySourceLocator = new Fabric8SecretsPropertySourceLocator(
+						kubernetesClient, secretsProperties, namespaceProvider);
+				bootstrapContext.registerIfAbsent(SecretsPropertySourceLocator.class,
+						InstanceSupplier.of(secretsPropertySourceLocator));
+				bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory()
+						.registerSingleton("configDataSecretsPropertySourceLocator",
+								event.getBootstrapContext().get(SecretsPropertySourceLocator.class)));
+			}
+		}
+	}
+
+	private void registerRetryBeans(ConfigMapConfigProperties configMapProperties,
+			SecretsConfigProperties secretsProperties, ConfigurableBootstrapContext bootstrapContext,
+			KubernetesClient kubernetesClient, KubernetesNamespaceProvider namespaceProvider) {
+		if (configMapProperties.isEnabled()) {
+			ConfigMapPropertySourceLocator configMapPropertySourceLocator = new Fabric8ConfigMapPropertySourceLocator(
+					kubernetesClient, configMapProperties, namespaceProvider);
+			if (isRetryEnabledForConfigMap(configMapProperties)) {
+				configMapPropertySourceLocator = new ConfigDataRetryableConfigMapPropertySourceLocator(
+						configMapPropertySourceLocator, configMapProperties);
+			}
+
+			bootstrapContext.registerIfAbsent(ConfigMapPropertySourceLocator.class,
+					InstanceSupplier.of(configMapPropertySourceLocator));
+			bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+					"configDataConfigMapPropertySourceLocator",
+					event.getBootstrapContext().get(ConfigMapPropertySourceLocator.class)));
+		}
+
+		if (secretsProperties.isEnabled()) {
+			SecretsPropertySourceLocator secretsPropertySourceLocator = new Fabric8SecretsPropertySourceLocator(
+					kubernetesClient, secretsProperties, namespaceProvider);
+			if (isRetryEnabledForSecrets(secretsProperties)) {
+				secretsPropertySourceLocator = new ConfigDataRetryableSecretsPropertySourceLocator(
+						secretsPropertySourceLocator, secretsProperties);
+			}
+			bootstrapContext.registerIfAbsent(SecretsPropertySourceLocator.class,
+					InstanceSupplier.of(secretsPropertySourceLocator));
+			bootstrapContext.addCloseListener(event -> event.getApplicationContext().getBeanFactory().registerSingleton(
+					"configDataSecretsPropertySourceLocator",
+					event.getBootstrapContext().get(SecretsPropertySourceLocator.class)));
+		}
+	}
+
+	protected KubernetesNamespaceProvider kubernetesNamespaceProvider(Environment environment) {
+		return new KubernetesNamespaceProvider(environment);
+	}
+
+	private Config config(KubernetesClientProperties properties) {
+		return new Fabric8AutoConfiguration().kubernetesClientConfig(properties);
+	}
+
+	private KubernetesClient kubernetesClient(Config config) {
+		return new Fabric8AutoConfiguration().kubernetesClient(config);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigDataLocationResolver.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8ConfigDataLocationResolver.java
@@ -51,10 +51,9 @@ public class Fabric8ConfigDataLocationResolver extends KubernetesConfigDataLocat
 	protected void registerBeans(ConfigDataLocationResolverContext resolverContext, ConfigDataLocation location,
 			Profiles profiles, KubernetesConfigDataLocationResolver.PropertyHolder propertyHolder,
 			KubernetesNamespaceProvider namespaceProvider) {
-		String uris = location.getNonPrefixedValue(getPrefix());
-		KubernetesClientProperties properties = propertyHolder.kubernetesClientProperties;
-		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapProperties;
-		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties;
+		KubernetesClientProperties properties = propertyHolder.kubernetesClientProperties();
+		ConfigMapConfigProperties configMapProperties = propertyHolder.configMapConfigProperties();
+		SecretsConfigProperties secretsProperties = propertyHolder.secretsProperties();
 
 		ConfigurableBootstrapContext bootstrapContext = resolverContext.getBootstrapContext();
 		Config config = config(properties);

--- a/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8RetryBootstrapConfiguration.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8RetryBootstrapConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.cloud.kubernetes.commons.KubernetesCommonsAutoConfiguration;
 import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
@@ -48,6 +49,7 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureAfter(KubernetesBootstrapConfiguration.class)
 @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
 @ConditionalOnKubernetesConfigOrSecretsRetryEnabled
+@ConditionalOnProperty(value = "spring.cloud.bootstrap.enabled", havingValue = "true")
 public class Fabric8RetryBootstrapConfiguration {
 
 	@Bean

--- a/spring-cloud-kubernetes-fabric8-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-kubernetes-fabric8-config/src/main/resources/META-INF/spring.factories
@@ -3,3 +3,6 @@ org.springframework.cloud.kubernetes.fabric8.config.reload.ConfigReloadAutoConfi
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
 org.springframework.cloud.kubernetes.fabric8.config.Fabric8BootstrapConfiguration,\
 org.springframework.cloud.kubernetes.fabric8.config.Fabric8RetryBootstrapConfiguration
+# ConfigData Location Resolvers
+org.springframework.boot.context.config.ConfigDataLocationResolver=\
+org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigDataLocationResolver

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BoostrapConfigMapsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BoostrapConfigMapsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-example", "spring.cloud.kubernetes.reload.enabled=false",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BoostrapConfigMapsTests extends ConfigMapsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BoostrapFabric8SecretsPropertySourceTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BoostrapFabric8SecretsPropertySourceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" })
+@TestPropertySource("classpath:/application-secrets.properties")
+@EnableKubernetesMockClient(crud = true, https = false)
+class BoostrapFabric8SecretsPropertySourceTest extends Fabric8SecretsPropertySourceTest {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BoostrapMultipleConfigMapsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BoostrapMultipleConfigMapsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example2.ExampleApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ExampleApp.class,
+		properties = { "spring.cloud.bootstrap.name=multiplecms", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BoostrapMultipleConfigMapsTests extends MultipleConfigMapsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapWithIncludeProfileSpecificSourcesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapWithIncludeProfileSpecificSourcesTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.include_profile_specific_sources.IncludeProfileSpecificSourcesApp;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author wind57
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = IncludeProfileSpecificSourcesApp.class,
+		properties = { "spring.cloud.bootstrap.name=include-profile-specific-sources",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+@ActiveProfiles("dev")
+class BootstrapConfigMapWithIncludeProfileSpecificSourcesTests extends ConfigMapWithIncludeProfileSpecificSourcesTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapWithPrefixTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapWithPrefixTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.with_prefix.WithPrefixApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author wind57
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = WithPrefixApp.class,
+		properties = { "spring.cloud.bootstrap.name=config-map-name-as-prefix", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+class BootstrapConfigMapWithPrefixTests extends ConfigMapWithPrefixTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsFromFilePathsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsFromFilePathsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class, properties = {
+		"spring.application.name=configmap-path-example", "spring.cloud.kubernetes.config.enableApi=false",
+		"spring.cloud.kubernetes.config.paths=" + BootstrapConfigMapsFromFilePathsTests.FIRST_FILE_NAME_FULL_PATH + ","
+				+ BootstrapConfigMapsFromFilePathsTests.SECOND_FILE_NAME_FULL_PATH + ","
+				+ BootstrapConfigMapsFromFilePathsTests.FIRST_FILE_NAME_DUPLICATED_FULL_PATH,
+		"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" })
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsFromFilePathsTests extends ConfigMapsFromFilePathsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() throws IOException {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsMixedTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsMixedTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=" + BootstrapConfigMapsMixedTests.APPLICATION_NAME,
+				"spring.cloud.kubernetes.config.enableApi=true",
+				"spring.cloud.kubernetes.config.paths=" + BootstrapConfigMapsMixedTests.FILE_NAME_FULL_PATH,
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" })
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsMixedTests extends ConfigMapsMixedTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() throws IOException {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithActiveProfilesNameTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithActiveProfilesNameTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Ali Shahbour
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-active-profile-name-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@ActiveProfiles("development")
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsWithActiveProfilesNameTests extends ConfigMapsWithActiveProfilesNameTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithProfileExpressionTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithProfileExpressionTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Tests reading property from YAML document specified by profile expression.
+ */
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-profile-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@ActiveProfiles({ "production", "us-east" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsWithProfileExpressionTests extends ConfigMapsWithProfileExpressionTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithProfilesNoActiveProfileTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithProfilesNoActiveProfileTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-profile-no-active-profiles-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsWithProfilesNoActiveProfileTests extends ConfigMapsWithProfilesNoActiveProfileTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithProfilesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithProfilesTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-profile-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@ActiveProfiles("development")
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsWithProfilesTests extends ConfigMapsWithProfilesTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithoutProfilesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapConfigMapsWithoutProfilesTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-without-profile-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@ActiveProfiles("development")
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapConfigMapsWithoutProfilesTests extends ConfigMapsWithoutProfilesTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapCoreTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapCoreTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestApplication.class,
+		properties = { "spring.application.name=testapp", "spring.cloud.kubernetes.client.namespace=testns",
+				"spring.cloud.kubernetes.client.trustCerts=true", "spring.cloud.kubernetes.config.namespace=testns",
+				"spring.cloud.kubernetes.secrets.enableApi=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapCoreTest extends CoreTest {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapCoreTestClientViaSystemProperties.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapCoreTestClientViaSystemProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestApplication.class,
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.application.name=testapp",
+				"spring.cloud.kubernetes.client.namespace=testns", "spring.cloud.kubernetes.client.trustCerts=true",
+				"spring.cloud.kubernetes.config.namespace=testns", "spring.cloud.kubernetes.secrets.enableApi=true",
+				"spring.cloud.bootstrap.enabled=true" })
+public class BootstrapCoreTestClientViaSystemProperties extends CoreTestClientViaSystemProperties {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapMultipleSecretsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/BootstrapMultipleSecretsTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example3.MultiSecretsApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Haytham Mohamed
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = MultiSecretsApp.class,
+		properties = { "spring.cloud.bootstrap.name=multiple-secrets", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class BootstrapMultipleSecretsTests extends MultipleSecretsTests {
+
+	// will be injected by KubernetesMockServerExtension
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapWithIncludeProfileSpecificSourcesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapWithIncludeProfileSpecificSourcesTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.include_profile_specific_sources.IncludeProfileSpecificSourcesApp;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author wind57
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = IncludeProfileSpecificSourcesApp.class,
+		properties = { "spring.application.name=include-profile-specific-sources",
+				"spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./include-profile-specific-sources.yaml" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+@ActiveProfiles("dev")
+class ConfigDataConfigMapWithIncludeProfileSpecificSourcesTests
+		extends ConfigMapWithIncludeProfileSpecificSourcesTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapWithPrefixTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapWithPrefixTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.with_prefix.WithPrefixApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author wind57
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = WithPrefixApp.class,
+		properties = { "spring.application.name=config-map-name-as-prefix", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./config-map-name-as-prefix.yaml" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+class ConfigDataConfigMapWithPrefixTests extends ConfigMapWithPrefixTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsFromFilePathsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsFromFilePathsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class, properties = {
+		"spring.application.name=configmap-path-example", "spring.cloud.kubernetes.config.enableApi=false",
+		"spring.cloud.kubernetes.config.paths=" + ConfigDataConfigMapsFromFilePathsTests.FIRST_FILE_NAME_FULL_PATH + ","
+				+ ConfigDataConfigMapsFromFilePathsTests.SECOND_FILE_NAME_FULL_PATH + ","
+				+ ConfigDataConfigMapsFromFilePathsTests.FIRST_FILE_NAME_DUPLICATED_FULL_PATH,
+		"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" })
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsFromFilePathsTests extends ConfigMapsFromFilePathsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() throws IOException {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsMixedTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsMixedTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import java.io.IOException;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=" + ConfigDataConfigMapsMixedTests.APPLICATION_NAME,
+				"spring.cloud.kubernetes.config.enableApi=true",
+				"spring.cloud.kubernetes.config.paths=" + ConfigDataConfigMapsMixedTests.FILE_NAME_FULL_PATH,
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" })
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsMixedTests extends ConfigMapsMixedTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() throws IOException {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-example", "spring.cloud.kubernetes.reload.enabled=false",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsTests extends ConfigMapsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithActiveProfilesNameTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithActiveProfilesNameTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Ali Shahbour
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-active-profile-name-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+@ActiveProfiles("development")
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsWithActiveProfilesNameTests extends ConfigMapsWithActiveProfilesNameTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithProfileExpressionTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithProfileExpressionTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Tests reading property from YAML document specified by profile expression.
+ */
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-profile-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+@ActiveProfiles({ "production", "us-east" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsWithProfileExpressionTests extends ConfigMapsWithProfileExpressionTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithProfilesNoActiveProfileTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithProfilesNoActiveProfileTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-profile-no-active-profiles-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsWithProfilesNoActiveProfileTests extends ConfigMapsWithProfilesNoActiveProfileTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithProfilesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithProfilesTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-with-profile-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+@ActiveProfiles("development")
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsWithProfilesTests extends ConfigMapsWithProfilesTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithoutProfilesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataConfigMapsWithoutProfilesTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.application.name=configmap-without-profile-example",
+				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+@ActiveProfiles("development")
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataConfigMapsWithoutProfilesTests extends ConfigMapsWithoutProfilesTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataCoreTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataCoreTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestApplication.class,
+		properties = { "spring.application.name=testapp", "spring.cloud.kubernetes.client.namespace=testns",
+				"spring.cloud.kubernetes.client.trustCerts=true", "spring.cloud.kubernetes.config.namespace=testns",
+				"spring.cloud.kubernetes.secrets.enableApi=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataCoreTest extends CoreTest {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataCoreTestClientViaSystemProperties.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataCoreTestClientViaSystemProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestApplication.class,
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.application.name=testapp",
+				"spring.cloud.kubernetes.client.namespace=testns", "spring.cloud.kubernetes.client.trustCerts=true",
+				"spring.cloud.kubernetes.config.namespace=testns", "spring.cloud.kubernetes.secrets.enableApi=true",
+				"spring.config.import=kubernetes:" })
+public class ConfigDataCoreTestClientViaSystemProperties extends CoreTestClientViaSystemProperties {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataFabric8SecretsPropertySourceTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataFabric8SecretsPropertySourceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example.App;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" })
+@TestPropertySource("classpath:/application-secrets.properties")
+@EnableKubernetesMockClient(crud = true, https = false)
+class ConfigDataFabric8SecretsPropertySourceTest extends Fabric8SecretsPropertySourceTest {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataMultipleConfigMapsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataMultipleConfigMapsTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example2.ExampleApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Charles Moulliard
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = ExampleApp.class,
+		properties = { "spring.application.name=multiplecms", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./multiplecms.yml" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataMultipleConfigMapsTests extends MultipleConfigMapsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataMultipleSecretsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigDataMultipleSecretsTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.example3.MultiSecretsApp;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Haytham Mohamed
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = MultiSecretsApp.class,
+		properties = { "spring.cloud.bootstrap.name=multiple-secrets", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./multiple-secrets.yml" })
+@AutoConfigureWebTestClient
+@EnableKubernetesMockClient(crud = true, https = false)
+public class ConfigDataMultipleSecretsTests extends MultipleSecretsTests {
+
+	// will be injected by KubernetesMockServerExtension
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapWithIncludeProfileSpecificSourcesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapWithIncludeProfileSpecificSourcesTests.java
@@ -22,41 +22,24 @@ import java.util.Map;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.include_profile_specific_sources.IncludeProfileSpecificSourcesApp;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * @author wind57
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		classes = IncludeProfileSpecificSourcesApp.class,
-		properties = { "spring.cloud.bootstrap.name=include-profile-specific-sources",
-				"spring.main.cloud-platform=KUBERNETES" })
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-@ActiveProfiles("dev")
-class ConfigMapWithIncludeProfileSpecificSourcesTests {
+abstract class ConfigMapWithIncludeProfileSpecificSourcesTests {
 
 	private static KubernetesClient mockClient;
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
-
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
+		ConfigMapWithIncludeProfileSpecificSourcesTests.mockClient = mockClient;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapWithPrefixTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapWithPrefixTests.java
@@ -22,9 +22,7 @@ import java.util.Map;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,17 +41,15 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 		properties = { "spring.cloud.bootstrap.name=config-map-name-as-prefix",
 				"spring.main.cloud-platform=KUBERNETES" })
 @AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-class ConfigMapWithPrefixTests {
+abstract class ConfigMapWithPrefixTests {
 
 	private static KubernetesClient mockClient;
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
-
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
+		ConfigMapWithPrefixTests.mockClient = mockClient;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsFromFilePathsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsFromFilePathsTests.java
@@ -22,9 +22,7 @@ import java.nio.file.Paths;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -44,8 +42,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 						+ ConfigMapsFromFilePathsTests.SECOND_FILE_NAME_FULL_PATH + ","
 						+ ConfigMapsFromFilePathsTests.FIRST_FILE_NAME_DUPLICATED_FULL_PATH,
 				"spring.main.cloud-platform=KUBERNETES" })
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsFromFilePathsTests {
+abstract class ConfigMapsFromFilePathsTests {
 
 	protected static final String FILES_ROOT_PATH = "/tmp/scktests";
 
@@ -66,13 +63,10 @@ public class ConfigMapsFromFilePathsTests {
 	protected static final String FIRST_FILE_NAME_DUPLICATED_FULL_PATH = FILES_ROOT_PATH + "/" + FILES_SUB_PATH + "/"
 			+ FIRST_FILE_NAME;
 
-	private static KubernetesClient mockClient;
-
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() throws IOException {
+	public static void setUpBeforeClass(KubernetesClient mockClient) throws IOException {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsMixedTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsMixedTests.java
@@ -25,28 +25,15 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.assertj.core.util.Lists.newArrayList;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=" + ConfigMapsMixedTests.APPLICATION_NAME,
-				"spring.cloud.kubernetes.config.enableApi=true",
-				"spring.cloud.kubernetes.config.paths=" + ConfigMapsMixedTests.FILE_NAME_FULL_PATH,
-				"spring.main.cloud-platform=KUBERNETES" })
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsMixedTests {
+abstract class ConfigMapsMixedTests {
 
 	protected static final String FILES_ROOT_PATH = "/tmp/scktests";
 
@@ -56,13 +43,10 @@ public class ConfigMapsMixedTests {
 
 	protected static final String APPLICATION_NAME = "configmap-mixed-example";
 
-	private static KubernetesClient mockClient;
-
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() throws IOException {
+	public static void setUpBeforeClass(KubernetesClient mockClient) throws IOException {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsTests.java
@@ -22,16 +22,9 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,13 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Charles Moulliard
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=configmap-example", "spring.cloud.kubernetes.reload.enabled=false",
-				"spring.main.cloud-platform=KUBERNETES" })
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsTests {
+abstract class ConfigMapsTests {
 
 	private static final String APPLICATION_NAME = "configmap-example";
 
@@ -57,9 +44,8 @@ public class ConfigMapsTests {
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
-
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
+		ConfigMapsTests.mockClient = mockClient;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithActiveProfilesNameTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithActiveProfilesNameTests.java
@@ -21,37 +21,19 @@ import java.util.HashMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.cloud.kubernetes.fabric8.config.ConfigMapTestUtil.readResourceFile;
 
 /**
  * @author Ali Shahbour
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=configmap-with-active-profile-name-example",
-				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
-@ActiveProfiles("development")
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsWithActiveProfilesNameTests {
+abstract class ConfigMapsWithActiveProfilesNameTests {
 
 	private static final String APPLICATION_NAME = "configmap-with-active-profile-name-example";
-
-	private static KubernetesClient mockClient;
 
 	@Autowired(required = false)
 	Config config;
@@ -59,9 +41,7 @@ public class ConfigMapsWithActiveProfilesNameTests {
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
-
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithProfileExpressionTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithProfileExpressionTests.java
@@ -21,41 +21,23 @@ import java.util.HashMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * Tests reading property from YAML document specified by profile expression.
  */
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=configmap-with-profile-example",
-				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
-@ActiveProfiles({ "production", "us-east" })
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsWithProfileExpressionTests {
-
-	private static KubernetesClient mockClient;
+abstract class ConfigMapsWithProfileExpressionTests {
 
 	private static final String APPLICATION_NAME = "configmap-with-profile-example";
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithProfilesNoActiveProfileTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithProfilesNoActiveProfileTests.java
@@ -21,16 +21,9 @@ import java.util.HashMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import static org.springframework.cloud.kubernetes.fabric8.config.ConfigMapTestUtil.readResourceFile;
@@ -38,23 +31,14 @@ import static org.springframework.cloud.kubernetes.fabric8.config.ConfigMapTestU
 /**
  * @author Charles Moulliard
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=configmap-with-profile-no-active-profiles-example",
-				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsWithProfilesNoActiveProfileTests {
+abstract class ConfigMapsWithProfilesNoActiveProfileTests {
 
 	private static final String APPLICATION_NAME = "configmap-with-profile-no-active-profiles-example";
-
-	private static KubernetesClient mockClient;
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithProfilesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithProfilesTests.java
@@ -21,34 +21,17 @@ import java.util.HashMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * @author Charles Moulliard
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=configmap-with-profile-example",
-				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
-@ActiveProfiles("development")
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsWithProfilesTests {
+abstract class ConfigMapsWithProfilesTests {
 
 	private static final String APPLICATION_NAME = "configmap-with-profile-example";
-
-	private static KubernetesClient mockClient;
 
 	@Autowired(required = false)
 	Config config;
@@ -56,8 +39,7 @@ public class ConfigMapsWithProfilesTests {
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithoutProfilesTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/ConfigMapsWithoutProfilesTests.java
@@ -21,37 +21,19 @@ import java.util.HashMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.application.name=configmap-without-profile-example",
-				"spring.cloud.kubernetes.reload.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
-@ActiveProfiles("development")
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class ConfigMapsWithoutProfilesTests {
+abstract class ConfigMapsWithoutProfilesTests {
 
 	private static final String APPLICATION_NAME = "configmap-without-profile-example";
-
-	private static KubernetesClient mockClient;
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/CoreTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/CoreTest.java
@@ -23,25 +23,14 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = TestApplication.class,
-		properties = { "spring.application.name=testapp", "spring.cloud.kubernetes.client.namespace=testns",
-				"spring.cloud.kubernetes.client.trustCerts=true", "spring.cloud.kubernetes.config.namespace=testns",
-				"spring.cloud.kubernetes.secrets.enableApi=true", "spring.main.cloud-platform=KUBERNETES" })
-@EnableKubernetesMockClient(crud = true, https = false)
-public class CoreTest {
+abstract class CoreTest {
 
 	private static KubernetesClient mockClient;
 
@@ -51,9 +40,8 @@ public class CoreTest {
 	@Autowired
 	private Config config;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
-
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
+		CoreTest.mockClient = mockClient;
 		Map<String, String> data1 = new HashMap<>();
 		data1.put("spring.kubernetes.test.value", "value1");
 		mockClient.configMaps().inNamespace("testns").create(

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/CoreTestClientViaSystemProperties.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/CoreTestClientViaSystemProperties.java
@@ -20,20 +20,12 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = TestApplication.class,
-		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.application.name=testapp",
-				"spring.cloud.kubernetes.client.namespace=testns", "spring.cloud.kubernetes.client.trustCerts=true",
-				"spring.cloud.kubernetes.config.namespace=testns", "spring.cloud.kubernetes.secrets.enableApi=true" })
-public class CoreTestClientViaSystemProperties {
+abstract class CoreTestClientViaSystemProperties {
 
 	@Autowired
 	private KubernetesClient client;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/Fabric8SecretsPropertySourceTest.java
@@ -22,32 +22,18 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example.App;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = "spring.main.cloud-platform=KUBERNETES")
-@TestPropertySource("classpath:/application-secrets.properties")
-@EnableKubernetesMockClient(crud = true, https = false)
-class Fabric8SecretsPropertySourceTest {
+abstract class Fabric8SecretsPropertySourceTest {
 
 	private static final String NAMESPACE = "test";
-
-	private static KubernetesClient mockClient;
 
 	private static final String SECRET_VALUE = "secretValue";
 
@@ -57,8 +43,7 @@ class Fabric8SecretsPropertySourceTest {
 	@Autowired
 	private Environment environment;
 
-	@BeforeAll
-	static void setUpBeforeClass() {
+	static void setUpBeforeClass(KubernetesClient mockClient) {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/KubernetesConfigConfigurationTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/KubernetesConfigConfigurationTest.java
@@ -41,11 +41,19 @@ public class KubernetesConfigConfigurationTest extends KubernetesConfigTestBase 
 	private static KubernetesClient mockClient;
 
 	@Test
-	public void kubernetesWhenKubernetesDefaultEnabled() {
+	public void kubernetesBootstrapWhenKubernetesDefaultEnabled() {
 		setup(KubernetesClientTestConfiguration.class, "spring.main.cloud-platform=KUBERNETES",
-				"spring.cloud.kubernetes.client.namespace=default");
+				"spring.cloud.kubernetes.client.namespace=default", "spring.cloud.bootstrap.enabled=true");
 		assertThat(getContext().containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(getContext().containsBean("secretsPropertySourceLocator")).isTrue();
+	}
+
+	@Test
+	public void kubernetesConfigDataWhenKubernetesDefaultEnabled() {
+		setup(KubernetesClientTestConfiguration.class, "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.kubernetes.client.namespace=default", "spring.config.import=kubernetes:");
+		assertThat(getContext().containsBean("configDataConfigMapPropertySourceLocator")).isTrue();
+		assertThat(getContext().containsBean("configDataSecretsPropertySourceLocator")).isTrue();
 	}
 
 	@Test
@@ -64,29 +72,57 @@ public class KubernetesConfigConfigurationTest extends KubernetesConfigTestBase 
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigEnabledButSecretDisabled() {
+	public void kubernetesBootstrapWhenKubernetesConfigEnabledButSecretDisabled() {
 		setup(KubernetesClientTestConfiguration.class, "spring.cloud.kubernetes.config.enabled=true",
 				"spring.cloud.kubernetes.secrets.enabled=false", "spring.cloud.kubernetes.client.namespace=default",
-				"spring.main.cloud-platform=KUBERNETES");
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true");
 		assertThat(getContext().containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(getContext().containsBean("secretsPropertySourceLocator")).isFalse();
 	}
 
 	@Test
-	public void kubernetesWhenKubernetesConfigDisabledButSecretEnabled() {
+	public void kubernetesConfigDataWhenKubernetesConfigEnabledButSecretDisabled() {
+		setup(KubernetesClientTestConfiguration.class, "spring.cloud.kubernetes.config.enabled=true",
+				"spring.cloud.kubernetes.secrets.enabled=false", "spring.cloud.kubernetes.client.namespace=default",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:");
+		assertThat(getContext().containsBean("configDataConfigMapPropertySourceLocator")).isTrue();
+		assertThat(getContext().containsBean("configDataSecretsPropertySourceLocator")).isFalse();
+	}
+
+	@Test
+	public void kubernetesBootstrapWhenKubernetesConfigDisabledButSecretEnabled() {
 		setup(KubernetesClientTestConfiguration.class, "spring.cloud.kubernetes.config.enabled=false",
-				"spring.cloud.kubernetes.secrets.enabled=true", "spring.main.cloud-platform=KUBERNETES");
+				"spring.cloud.kubernetes.secrets.enabled=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true");
 		assertThat(getContext().containsBean("configMapPropertySourceLocator")).isFalse();
 		assertThat(getContext().containsBean("secretsPropertySourceLocator")).isTrue();
 	}
 
 	@Test
-	public void kubernetesConfigWhenKubernetesEnabledAndKubernetesConfigEnabled() {
+	public void kubernetesConfigDataWhenKubernetesConfigDisabledButSecretEnabled() {
+		setup(KubernetesClientTestConfiguration.class, "spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:");
+		assertThat(getContext().containsBean("configDataConfigMapPropertySourceLocator")).isFalse();
+		assertThat(getContext().containsBean("configDataSecretsPropertySourceLocator")).isTrue();
+	}
+
+	@Test
+	public void kubernetesBootstrapConfigWhenKubernetesEnabledAndKubernetesConfigEnabled() {
 		setup(KubernetesClientTestConfiguration.class, "spring.cloud.kubernetes.config.enabled=true",
 				"spring.cloud.kubernetes.secrets.enabled=true", "spring.cloud.kubernetes.client.namespace=default",
-				"spring.main.cloud-platform=KUBERNETES");
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true");
 		assertThat(getContext().containsBean("configMapPropertySourceLocator")).isTrue();
 		assertThat(getContext().containsBean("secretsPropertySourceLocator")).isTrue();
+	}
+
+	@Test
+	public void kubernetesConfigDataConfigWhenKubernetesEnabledAndKubernetesConfigEnabled() {
+		setup(KubernetesClientTestConfiguration.class, "spring.cloud.kubernetes.config.enabled=true",
+				"spring.cloud.kubernetes.secrets.enabled=true", "spring.cloud.kubernetes.client.namespace=default",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:");
+		assertThat(getContext().containsBean("configDataConfigMapPropertySourceLocator")).isTrue();
+		assertThat(getContext().containsBean("configDataSecretsPropertySourceLocator")).isTrue();
 	}
 
 	@Test

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/KubernetesConfigTestBase.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/KubernetesConfigTestBase.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.kubernetes.fabric8.config;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.AfterEach;
 
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
@@ -32,14 +35,18 @@ public class KubernetesConfigTestBase {
 
 	private ConfigurableApplicationContext context;
 
+	protected String[] commonProperties = new String[0];
+
 	protected ConfigurableApplicationContext getContext() {
 		return context;
 	}
 
 	protected void setup(Class<?> mockClientConfiguration, String... env) {
+		String[] properties = Stream.concat(Arrays.stream(commonProperties), Arrays.stream(env))
+				.toArray(size -> new String[size]);
 		context = new SpringApplicationBuilder(PropertyPlaceholderAutoConfiguration.class, mockClientConfiguration,
 				BootstrapConfiguration.class, ConfigReloadAutoConfiguration.class, RefreshAutoConfiguration.class)
-						.web(org.springframework.boot.WebApplicationType.NONE).properties(env).run();
+						.web(org.springframework.boot.WebApplicationType.NONE).properties(properties).run();
 	}
 
 	@AfterEach

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/MultipleConfigMapsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/MultipleConfigMapsTests.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -42,15 +41,12 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 		properties = { "spring.cloud.bootstrap.name=multiplecms", "spring.main.cloud-platform=KUBERNETES" })
 @AutoConfigureWebTestClient
 @EnableKubernetesMockClient(crud = true, https = false)
-public class MultipleConfigMapsTests {
-
-	private static KubernetesClient mockClient;
+abstract class MultipleConfigMapsTests {
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/MultipleSecretsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/MultipleSecretsTests.java
@@ -24,27 +24,15 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.example3.MultiSecretsApp;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * @author Haytham Mohamed
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = MultiSecretsApp.class,
-		properties = { "spring.cloud.bootstrap.name=multiple-secrets", "spring.main.cloud-platform=KUBERNETES" })
-@AutoConfigureWebTestClient
-@EnableKubernetesMockClient(crud = true, https = false)
-public class MultipleSecretsTests {
+abstract class MultipleSecretsTests {
 
 	private static final String DEFAULT_NAMESPACE = "ns1";
 
@@ -54,14 +42,10 @@ public class MultipleSecretsTests {
 
 	private static final String SECRET_VALUE_2 = "secretValue-2";
 
-	// will be injected by KubernetesMockServerExtension
-	private static KubernetesClient mockClient;
-
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	public static void setUpBeforeClass() {
+	public static void setUpBeforeClass(KubernetesClient mockClient) {
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BoostrapKubernetesEnabledConfigDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BoostrapKubernetesEnabledConfigDisabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.config.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+class BoostrapKubernetesEnabledConfigDisabled extends KubernetesEnabledConfigDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesDisabled.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.enabled=false", "spring.cloud.bootstrap.enabled=true" })
+class BootstrapKubernetesDisabled extends KubernetesDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesDisabled.java
@@ -23,7 +23,7 @@ import org.springframework.cloud.kubernetes.fabric8.config.Application;
  * @author wind57
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.enabled=false", "spring.cloud.bootstrap.enabled=true" })
+		properties = { "spring.cloud.bootstrap.enabled=true" })
 class BootstrapKubernetesDisabled extends KubernetesDisabled {
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+class BootstrapKubernetesEnabled extends KubernetesEnabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabledOnPurpose.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabledOnPurpose.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.secrets.enabled=true",
+				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+class BootstrapKubernetesEnabledOnPurpose extends KubernetesEnabledOnPurpose {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabledSecretsAndConfigDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabledSecretsAndConfigDisabled.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.secrets.enabled=false", "spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.bootstrap.enabled=true" })
+class BootstrapKubernetesEnabledSecretsAndConfigDisabled extends KubernetesEnabledSecretsAndConfigDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabledSecretsDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/BootstrapKubernetesEnabledSecretsDisabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.secrets.enabled=false",
+				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+class BootstrapKubernetesEnabledSecretsDisabled extends KubernetesEnabledSecretsDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesDisabled.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
+class ConfigDataKubernetesDisabled extends KubernetesDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesDisabled.java
@@ -23,7 +23,7 @@ import org.springframework.cloud.kubernetes.fabric8.config.Application;
  * @author wind57
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
+		properties = { "spring.main.cloud-platform=KUBERNETES" })
 class ConfigDataKubernetesDisabled extends KubernetesDisabled {
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+class ConfigDataKubernetesEnabled extends KubernetesEnabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledConfigDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledConfigDisabled.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.config.enabled=false", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+class ConfigDataKubernetesEnabledConfigDisabled extends KubernetesEnabledConfigDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledOnPurpose.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledOnPurpose.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.secrets.enabled=true",
+				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+class ConfigDataKubernetesEnabledOnPurpose extends KubernetesEnabledOnPurpose {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledSecretsAndConfigDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledSecretsAndConfigDisabled.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.secrets.enabled=false", "spring.cloud.kubernetes.config.enabled=false",
+				"spring.config.import=kubernetes:", "spring.main.cloud-platform=KUBERNETES" })
+class ConfigDataKubernetesEnabledSecretsAndConfigDisabled extends KubernetesEnabledSecretsAndConfigDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledSecretsDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/ConfigDataKubernetesEnabledSecretsDisabled.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
+		properties = { "spring.cloud.kubernetes.secrets.enabled=false",
+				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" })
+class ConfigDataKubernetesEnabledSecretsDisabled extends KubernetesEnabledSecretsDisabled {
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/Fabric8BootstrapConfigurationInsideK8s.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/Fabric8BootstrapConfigurationInsideK8s.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author wind57
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=abc" })
+		properties = { "spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.client.namespace=abc",
+				"spring.cloud.bootstrap.enabled=true" })
 class Fabric8BootstrapConfigurationInsideK8s {
 
 	@Autowired

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesDisabled.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -30,9 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = "spring.cloud.kubernetes.enabled=false")
-class KubernetesDisabled {
+abstract class KubernetesDisabled {
 
 	@Autowired
 	private ConfigurableApplicationContext context;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabled.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -30,9 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" })
-class KubernetesEnabled {
+abstract class KubernetesEnabled {
 
 	@Autowired
 	private ConfigurableApplicationContext context;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledConfigDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledConfigDisabled.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -30,9 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.config.enabled=false", "spring.main.cloud-platform=KUBERNETES" })
-class KubernetesEnabledConfigDisabled {
+abstract class KubernetesEnabledConfigDisabled {
 
 	@Autowired
 	private ConfigurableApplicationContext context;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledOnPurpose.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledOnPurpose.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -30,10 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.secrets.enabled=true",
-				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" })
-class KubernetesEnabledOnPurpose {
+abstract class KubernetesEnabledOnPurpose {
 
 	@Autowired
 	private ConfigurableApplicationContext context;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledSecretsAndConfigDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledSecretsAndConfigDisabled.java
@@ -19,17 +19,13 @@ package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties = {
-		"spring.cloud.kubernetes.secrets.enabled=false", "spring.cloud.kubernetes.config.enabled=false" })
-class KubernetesEnabledSecretsAndConfigDisabled {
+abstract class KubernetesEnabledSecretsAndConfigDisabled {
 
 	@Autowired
 	private ConfigurableApplicationContext context;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledSecretsDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/bootstrap/KubernetesEnabledSecretsDisabled.java
@@ -19,8 +19,6 @@ package org.springframework.cloud.kubernetes.fabric8.config.bootstrap;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -30,10 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class,
-		properties = { "spring.cloud.kubernetes.secrets.enabled=false",
-				"spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES" })
-class KubernetesEnabledSecretsDisabled {
+abstract class KubernetesEnabledSecretsDisabled {
 
 	@Autowired
 	private ConfigurableApplicationContext context;

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BoostrapConfigFailFastDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BoostrapConfigFailFastDisabled.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BoostrapConfigFailFastDisabled extends ConfigFailFastDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BoostrapConfigRetryDisabledButSecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BoostrapConfigRetryDisabledButSecretsRetryEnabled.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BoostrapConfigRetryDisabledButSecretsRetryEnabled extends ConfigRetryDisabledButSecretsRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@Override
+	protected void assertRetryBean(ApplicationContext context) {
+		assertThat(context.containsBean("kubernetesConfigRetryInterceptor")).isTrue();
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BoostrapConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BoostrapConfigRetryEnabled.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.max-attempts=5",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BoostrapConfigRetryEnabled extends ConfigRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@SpyBean
+	Fabric8ConfigMapPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = propertySourceLocator;
+		verifiablePsl = propertySourceLocator;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BootstrapConfigFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/BootstrapConfigFailFastEnabledButRetryDisabled.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * we call Fabric8ConfigMapPropertySourceLocator::locate directly, thus no need for
+ * bootstrap phase to kick in. As such two flags that might look a bit un-expected:
+ * "spring.cloud.kubernetes.config.enabled=false"
+ * "spring.cloud.kubernetes.secrets.enabled=false"
+ *
+ * @author Isik Erhan
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=false", "spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BootstrapConfigFailFastEnabledButRetryDisabled extends ConfigFailFastEnabledButRetryDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigFailFastDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigFailFastDisabled.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataConfigFailFastDisabled extends ConfigFailFastDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigFailFastEnabledButRetryDisabled.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+/**
+ * we call Fabric8ConfigMapPropertySourceLocator::locate directly, thus no need for
+ * bootstrap phase to kick in. As such two flags that might look a bit un-expected:
+ * "spring.cloud.kubernetes.config.enabled=false"
+ * "spring.cloud.kubernetes.secrets.enabled=false"
+ *
+ * @author Isik Erhan
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.config.enabled=false",
+				"spring.cloud.kubernetes.secrets.enabled=false", "spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataConfigFailFastEnabledButRetryDisabled extends ConfigFailFastEnabledButRetryDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@MockBean
+	KubernetesNamespaceProvider kubernetesNamespaceProvider;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigRetryDisabledButSecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigRetryDisabledButSecretsRetryEnabled.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableSecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataConfigRetryDisabledButSecretsRetryEnabled extends ConfigRetryDisabledButSecretsRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@Override
+	protected void assertRetryBean(ApplicationContext context) {
+		assertThat(context.getBean(ConfigDataRetryableSecretsPropertySourceLocator.class)).isNotNull();
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigDataConfigRetryEnabled.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.max-attempts=5",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataConfigRetryEnabled extends ConfigRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@MockBean
+	private KubernetesNamespaceProvider namespaceProvider;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@Autowired
+	ConfigDataRetryableConfigMapPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = propertySourceLocator;
+		verifiablePsl = spy(propertySourceLocator.getConfigMapPropertySourceLocator());
+		propertySourceLocator.setConfigMapPropertySourceLocator(verifiablePsl);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigFailFastEnabledButRetryDisabled.java
@@ -18,15 +18,11 @@ package org.springframework.cloud.kubernetes.fabric8.config.locator_retry;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
 import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
@@ -46,14 +42,7 @@ import static org.mockito.Mockito.verify;
  * @author Isik Erhan
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default",
-				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.enabled=false",
-				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.kubernetes.config.enabled=false",
-				"spring.cloud.kubernetes.secrets.enabled=false" },
-		classes = Application.class)
-@EnableKubernetesMockClient
-class ConfigFailFastEnabledButRetryDisabled {
+abstract class ConfigFailFastEnabledButRetryDisabled {
 
 	private static final String API = "/api/v1/namespaces/default/configmaps/application";
 
@@ -61,8 +50,9 @@ class ConfigFailFastEnabledButRetryDisabled {
 
 	private static KubernetesClient mockClient;
 
-	@BeforeAll
-	static void setup() {
+	static void setup(KubernetesClient mockClient, KubernetesMockServer mockServer) {
+		ConfigFailFastEnabledButRetryDisabled.mockClient = mockClient;
+		ConfigFailFastEnabledButRetryDisabled.mockServer = mockServer;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/locator_retry/ConfigRetryEnabled.java
@@ -22,16 +22,11 @@ import java.util.Map;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
-import org.springframework.cloud.kubernetes.fabric8.config.Fabric8ConfigMapPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.ConfigMapPropertySourceLocator;
 import org.springframework.core.env.PropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -44,13 +39,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default",
-				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.config.retry.max-attempts=5",
-				"spring.main.cloud-platform=KUBERNETES" },
-		classes = Application.class)
-@EnableKubernetesMockClient
-class ConfigRetryEnabled {
+abstract class ConfigRetryEnabled {
 
 	private static final String API = "/api/v1/namespaces/default/configmaps/application";
 
@@ -58,8 +47,13 @@ class ConfigRetryEnabled {
 
 	private static KubernetesClient mockClient;
 
-	@BeforeAll
-	static void setup() {
+	protected ConfigMapPropertySourceLocator psl;
+
+	protected ConfigMapPropertySourceLocator verifiablePsl;
+
+	static void setup(KubernetesClient mockClient, KubernetesMockServer mockServer) {
+		ConfigRetryEnabled.mockClient = mockClient;
+		ConfigRetryEnabled.mockServer = mockServer;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
@@ -67,9 +61,6 @@ class ConfigRetryEnabled {
 		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
 		System.setProperty(Config.KUBERNETES_HTTP2_DISABLE, "true");
 	}
-
-	@SpyBean
-	private Fabric8ConfigMapPropertySourceLocator propertySourceLocator;
 
 	@Test
 	void locateShouldNotRetryWhenThereIsNoFailure() {
@@ -82,11 +73,10 @@ class ConfigRetryEnabled {
 				new ConfigMapBuilder().withNewMetadata().withName("application").endMetadata().addToData(data).build())
 				.once();
 
-		PropertySource<?> propertySource = Assertions
-				.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+		PropertySource<?> propertySource = Assertions.assertDoesNotThrow(() -> psl.locate(new MockEnvironment()));
 
 		// verify locate is called only once
-		verify(propertySourceLocator, times(1)).locate(any());
+		verify(verifiablePsl, times(1)).locate(any());
 
 		// validate the contents of the property source
 		assertThat(propertySource.getProperty("some.prop")).isEqualTo("theValue");
@@ -105,11 +95,10 @@ class ConfigRetryEnabled {
 				new ConfigMapBuilder().withNewMetadata().withName("application").endMetadata().addToData(data).build())
 				.once();
 
-		PropertySource<?> propertySource = Assertions
-				.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+		PropertySource<?> propertySource = Assertions.assertDoesNotThrow(() -> psl.locate(new MockEnvironment()));
 
 		// verify retried 4 times
-		verify(propertySourceLocator, times(4)).locate(any());
+		verify(verifiablePsl, times(4)).locate(any());
 
 		// validate the contents of the property source
 		assertThat(propertySource.getProperty("some.prop")).isEqualTo("theValue");
@@ -121,12 +110,11 @@ class ConfigRetryEnabled {
 		// fail all the 5 requests
 		mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").times(5);
 
-		assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
-				.isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> psl.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
 				.hasMessage("Unable to read ConfigMap with name 'application' in namespace 'default'");
 
 		// verify retried 5 times until failure
-		verify(propertySourceLocator, times(5)).locate(any());
+		verify(verifiablePsl, times(5)).locate(any());
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/reload/ConfigReloadAutoConfigurationTest.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/reload/ConfigReloadAutoConfigurationTest.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -72,6 +73,11 @@ public class ConfigReloadAutoConfigurationTest extends KubernetesConfigTestBase 
 		ConfigMap configMap2 = new ConfigMapBuilder().withNewMetadata().withName(APPLICATION_NAME).endMetadata()
 				.addToData(data).build();
 		mockClient.configMaps().inNamespace("spring").create(configMap2);
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		commonProperties = new String[] { "spring.cloud.bootstrap.enabled=true" };
 	}
 
 	@Test

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsFailFastDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsFailFastDisabled.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BootstrapSecretsFailFastDisabled extends SecretsFailFastDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@SpyBean
+	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = propertySourceLocator;
+		verifiablePsl = propertySourceLocator;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsFailFastEnabledButRetryDisabled.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
+				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BootstrapSecretsFailFastEnabledButRetryDisabled extends SecretsFailFastEnabledButRetryDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@SpyBean
+	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = propertySourceLocator;
+		verifiablePsl = propertySourceLocator;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsRetryDisabledButConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsRetryDisabledButConfigRetryEnabled.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.secrets.name=my-secret",
+				"spring.cloud.kubernetes.secrets.enable-api=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BootstrapSecretsRetryDisabledButConfigRetryEnabled extends SecretsRetryDisabledButConfigRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@SpyBean
+	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = propertySourceLocator;
+		verifiablePsl = propertySourceLocator;
+	}
+
+	@Override
+	protected void assertRetryBean(ApplicationContext context) {
+		assertThat(context.containsBean("kubernetesSecretsRetryInterceptor")).isTrue();
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/BootstrapSecretsRetryEnabled.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.fail-fast=true",
+				"spring.cloud.kubernetes.secrets.retry.max-attempts=5",
+				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.cloud.bootstrap.enabled=true" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class BootstrapSecretsRetryEnabled extends SecretsRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@SpyBean
+	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = propertySourceLocator;
+		verifiablePsl = propertySourceLocator;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsFailFastDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsFailFastDisabled.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataSecretsFailFastDisabled extends SecretsFailFastDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@Autowired
+	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = spy(propertySourceLocator);
+		verifiablePsl = psl;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsFailFastEnabledButRetryDisabled.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
+				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataSecretsFailFastEnabledButRetryDisabled extends SecretsFailFastEnabledButRetryDisabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@Autowired
+	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = spy(propertySourceLocator);
+		verifiablePsl = psl;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsRetryDisabledButConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsRetryDisabledButConfigRetryEnabled.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
+				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.secrets.name=my-secret",
+				"spring.cloud.kubernetes.secrets.enable-api=true", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataSecretsRetryDisabledButConfigRetryEnabled extends SecretsRetryDisabledButConfigRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@Autowired
+	private Fabric8SecretsPropertySourceLocator secretsPropertySourceLocator;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = spy(secretsPropertySourceLocator);
+		verifiablePsl = psl;
+	}
+
+	@Override
+	protected void assertRetryBean(ApplicationContext context) {
+		assertThat(context.containsBean("configDataSecretsPropertySourceLocator")).isTrue();
+		assertThat(context.getBean("configDataSecretsPropertySourceLocator"))
+				.isInstanceOf(Fabric8SecretsPropertySourceLocator.class);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/ConfigDataSecretsRetryEnabled.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.retry;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.kubernetes.commons.config.ConfigDataRetryableSecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.fabric8.config.Application;
+
+import static org.mockito.Mockito.spy;
+
+/**
+ * @author Isik Erhan
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "spring.cloud.kubernetes.client.namespace=default",
+				"spring.cloud.kubernetes.secrets.fail-fast=true",
+				"spring.cloud.kubernetes.secrets.retry.max-attempts=5",
+				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
+				"spring.main.cloud-platform=KUBERNETES", "spring.config.import=kubernetes:" },
+		classes = Application.class)
+@EnableKubernetesMockClient
+class ConfigDataSecretsRetryEnabled extends SecretsRetryEnabled {
+
+	private static KubernetesMockServer mockServer;
+
+	private static KubernetesClient mockClient;
+
+	@Autowired
+	private ConfigDataRetryableSecretsPropertySourceLocator configDataRetryableSecretsPropertySourceLocator;
+
+	@BeforeAll
+	static void setup() {
+		setup(mockClient, mockServer);
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		psl = configDataRetryableSecretsPropertySourceLocator;
+		verifiablePsl = spy(configDataRetryableSecretsPropertySourceLocator.getSecretsPropertySourceLocator());
+		configDataRetryableSecretsPropertySourceLocator.setSecretsPropertySourceLocator(verifiablePsl);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsFailFastDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsFailFastDisabled.java
@@ -19,16 +19,11 @@ package org.springframework.cloud.kubernetes.fabric8.config.retry;
 import io.fabric8.kubernetes.api.model.SecretListBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
-import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.SecretsPropertySourceLocator;
 import org.springframework.mock.env.MockEnvironment;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -38,13 +33,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default",
-				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
-				"spring.main.cloud-platform=KUBERNETES" },
-		classes = Application.class)
-@EnableKubernetesMockClient
-class SecretsFailFastDisabled {
+abstract class SecretsFailFastDisabled {
 
 	private static final String API = "/api/v1/namespaces/default/secrets/my-secret";
 
@@ -54,8 +43,13 @@ class SecretsFailFastDisabled {
 
 	private static KubernetesClient mockClient;
 
-	@BeforeAll
-	static void setup() {
+	protected SecretsPropertySourceLocator psl;
+
+	protected SecretsPropertySourceLocator verifiablePsl;
+
+	static void setup(KubernetesClient mockClient, KubernetesMockServer mockServer) {
+		SecretsFailFastDisabled.mockClient = mockClient;
+		SecretsFailFastDisabled.mockServer = mockServer;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
@@ -67,17 +61,14 @@ class SecretsFailFastDisabled {
 		mockServer.expect().withPath(LIST_API).andReturn(200, new SecretListBuilder().build()).always();
 	}
 
-	@SpyBean
-	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
-
 	@Test
 	void locateShouldNotRetry() {
 		mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
 
-		Assertions.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+		Assertions.assertDoesNotThrow(() -> psl.locate(new MockEnvironment()));
 
 		// verify locate is called only once
-		verify(propertySourceLocator, times(1)).locate(any());
+		verify(verifiablePsl, times(1)).locate(any());
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsFailFastEnabledButRetryDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsFailFastEnabledButRetryDisabled.java
@@ -19,16 +19,11 @@ package org.springframework.cloud.kubernetes.fabric8.config.retry;
 import io.fabric8.kubernetes.api.model.SecretListBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
-import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.SecretsPropertySourceLocator;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -41,14 +36,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default",
-				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
-				"spring.cloud.kubernetes.secrets.name=my-secret", "spring.cloud.kubernetes.secrets.enable-api=true",
-				"spring.main.cloud-platform=KUBERNETES" },
-		classes = Application.class)
-@EnableKubernetesMockClient
-class SecretsFailFastEnabledButRetryDisabled {
+abstract class SecretsFailFastEnabledButRetryDisabled {
 
 	private static final String API = "/api/v1/namespaces/default/secrets/my-secret";
 
@@ -58,8 +46,13 @@ class SecretsFailFastEnabledButRetryDisabled {
 
 	private static KubernetesClient mockClient;
 
-	@BeforeAll
-	static void setup() {
+	protected SecretsPropertySourceLocator psl;
+
+	protected SecretsPropertySourceLocator verifiablePsl;
+
+	static void setup(KubernetesClient mockClient, KubernetesMockServer mockServer) {
+		SecretsFailFastEnabledButRetryDisabled.mockClient = mockClient;
+		SecretsFailFastEnabledButRetryDisabled.mockServer = mockServer;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
@@ -71,9 +64,6 @@ class SecretsFailFastEnabledButRetryDisabled {
 		mockServer.expect().withPath(LIST_API).andReturn(200, new SecretListBuilder().build()).always();
 	}
 
-	@SpyBean
-	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
-
 	@Autowired
 	private ApplicationContext context;
 
@@ -83,12 +73,11 @@ class SecretsFailFastEnabledButRetryDisabled {
 		mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
 
 		assertThat(context.containsBean("kubernetesSecretsRetryInterceptor")).isFalse();
-		assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
-				.isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> psl.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
 				.hasMessage("Unable to read Secret with name 'my-secret' in namespace 'default'");
 
 		// verify that propertySourceLocator.locate is called only once
-		verify(propertySourceLocator, times(1)).locate(any());
+		verify(verifiablePsl, times(1)).locate(any());
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsRetryDisabledButConfigRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsRetryDisabledButConfigRetryEnabled.java
@@ -19,20 +19,14 @@ package org.springframework.cloud.kubernetes.fabric8.config.retry;
 import io.fabric8.kubernetes.api.model.SecretListBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
-import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.SecretsPropertySourceLocator;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -41,14 +35,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "spring.cloud.kubernetes.client.namespace=default",
-				"spring.cloud.kubernetes.secrets.fail-fast=true", "spring.cloud.kubernetes.secrets.retry.enabled=false",
-				"spring.cloud.kubernetes.config.fail-fast=true", "spring.cloud.kubernetes.secrets.name=my-secret",
-				"spring.cloud.kubernetes.secrets.enable-api=true", "spring.main.cloud-platform=KUBERNETES" },
-		classes = Application.class)
-@EnableKubernetesMockClient
-class SecretsRetryDisabledButConfigRetryEnabled {
+abstract class SecretsRetryDisabledButConfigRetryEnabled {
 
 	private static final String API = "/api/v1/namespaces/default/secrets/my-secret";
 
@@ -58,8 +45,13 @@ class SecretsRetryDisabledButConfigRetryEnabled {
 
 	private static KubernetesClient mockClient;
 
-	@BeforeAll
-	static void setup() {
+	protected SecretsPropertySourceLocator psl;
+
+	protected SecretsPropertySourceLocator verifiablePsl;
+
+	protected static void setup(KubernetesClient mockClient, KubernetesMockServer mockServer) {
+		SecretsRetryDisabledButConfigRetryEnabled.mockClient = mockClient;
+		SecretsRetryDisabledButConfigRetryEnabled.mockServer = mockServer;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
@@ -71,15 +63,11 @@ class SecretsRetryDisabledButConfigRetryEnabled {
 		mockServer.expect().withPath(LIST_API).andReturn(200, new SecretListBuilder().build()).always();
 	}
 
-	@SpyBean
-	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
-
 	@Autowired
 	private ApplicationContext context;
 
 	@Test
 	void locateShouldFailWithoutRetrying() {
-
 		/*
 		 * Enabling config retry causes Spring Retry to be enabled and a
 		 * RetryOperationsInterceptor bean with NeverRetryPolicy for secrets to be
@@ -89,13 +77,14 @@ class SecretsRetryDisabledButConfigRetryEnabled {
 
 		mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").once();
 
-		assertThat(context.containsBean("kubernetesSecretsRetryInterceptor")).isTrue();
-		assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
-				.isInstanceOf(IllegalStateException.class)
+		assertRetryBean(context);
+		assertThatThrownBy(() -> psl.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
 				.hasMessage("Unable to read Secret with name 'my-secret' in namespace 'default'");
 
 		// verify that propertySourceLocator.locate is called only once
-		verify(propertySourceLocator, times(1)).locate(any());
+		verify(verifiablePsl, times(1)).locate(any());
 	}
+
+	protected abstract void assertRetryBean(ApplicationContext context);
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsRetryEnabled.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/retry/SecretsRetryEnabled.java
@@ -24,16 +24,11 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretListBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.cloud.kubernetes.fabric8.config.Application;
-import org.springframework.cloud.kubernetes.fabric8.config.Fabric8SecretsPropertySourceLocator;
+import org.springframework.cloud.kubernetes.commons.config.SecretsPropertySourceLocator;
 import org.springframework.core.env.PropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -46,13 +41,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Isik Erhan
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
-		"spring.cloud.kubernetes.client.namespace=default", "spring.cloud.kubernetes.secrets.fail-fast=true",
-		"spring.cloud.kubernetes.secrets.retry.max-attempts=5", "spring.cloud.kubernetes.secrets.name=my-secret",
-		"spring.cloud.kubernetes.secrets.enable-api=true", "spring.main.cloud-platform=KUBERNETES" },
-		classes = Application.class)
-@EnableKubernetesMockClient
-class SecretsRetryEnabled {
+abstract class SecretsRetryEnabled {
 
 	private static final String API = "/api/v1/namespaces/default/secrets/my-secret";
 
@@ -60,10 +49,12 @@ class SecretsRetryEnabled {
 
 	private static KubernetesMockServer mockServer;
 
-	private static KubernetesClient mockClient;
+	protected SecretsPropertySourceLocator psl;
 
-	@BeforeAll
-	static void setup() {
+	protected SecretsPropertySourceLocator verifiablePsl;
+
+	static void setup(KubernetesClient mockClient, KubernetesMockServer mockServer) {
+		SecretsRetryEnabled.mockServer = mockServer;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
@@ -74,9 +65,6 @@ class SecretsRetryEnabled {
 		// return empty secret list to not fail context creation
 		mockServer.expect().withPath(LIST_API).andReturn(200, new SecretListBuilder().build()).always();
 	}
-
-	@SpyBean
-	private Fabric8SecretsPropertySourceLocator propertySourceLocator;
 
 	@Test
 	void locateShouldNotRetryWhenThereIsNoFailure() {
@@ -89,11 +77,10 @@ class SecretsRetryEnabled {
 				new SecretBuilder().withNewMetadata().withName("my-secret").endMetadata().addToData(data).build())
 				.once();
 
-		PropertySource<?> propertySource = Assertions
-				.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+		PropertySource<?> propertySource = Assertions.assertDoesNotThrow(() -> psl.locate(new MockEnvironment()));
 
 		// verify locate is called only once
-		verify(propertySourceLocator, times(1)).locate(any());
+		verify(verifiablePsl, times(1)).locate(any());
 
 		// validate the contents of the property source
 		assertThat(propertySource.getProperty("some.sensitive.prop")).isEqualTo("theSensitiveValue");
@@ -112,11 +99,10 @@ class SecretsRetryEnabled {
 				new SecretBuilder().withNewMetadata().withName("my-secret").endMetadata().addToData(data).build())
 				.once();
 
-		PropertySource<?> propertySource = Assertions
-				.assertDoesNotThrow(() -> propertySourceLocator.locate(new MockEnvironment()));
+		PropertySource<?> propertySource = Assertions.assertDoesNotThrow(() -> psl.locate(new MockEnvironment()));
 
 		// verify retried 4 times
-		verify(propertySourceLocator, times(4)).locate(any());
+		verify(verifiablePsl, times(4)).locate(any());
 
 		// validate the contents of the property source
 		assertThat(propertySource.getProperty("some.sensitive.prop")).isEqualTo("theSensitiveValue");
@@ -128,12 +114,12 @@ class SecretsRetryEnabled {
 		// fail all the 5 requests
 		mockServer.expect().withPath(API).andReturn(500, "Internal Server Error").times(5);
 
-		assertThatThrownBy(() -> propertySourceLocator.locate(new MockEnvironment()))
-				.isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> psl.locate(new MockEnvironment())).isInstanceOf(IllegalStateException.class)
 				.hasMessage("Unable to read Secret with name 'my-secret' in namespace 'default'");
 
 		// verify retried 5 times until failure
-		verify(propertySourceLocator, times(5)).locate(any());
+		verify(verifiablePsl, times(5)).locate(any());
+
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/BootstrapSecretsWithLabelsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/BootstrapSecretsWithLabelsTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.secrets_with_labels;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SecretsWithLabelsApp.class,
+		properties = { "spring.cloud.bootstrap.name=secret-with-labels-config", "spring.main.cloud-platform=KUBERNETES",
+				"spring.cloud.bootstrap.enabled=true" })
+@EnableKubernetesMockClient(crud = true, https = false)
+class BootstrapSecretsWithLabelsTests extends SecretsWithLabelsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/ConfigDataSecretsWithLabelsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/ConfigDataSecretsWithLabelsTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.secrets_with_labels;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SecretsWithLabelsApp.class,
+		properties = { "spring.application.name=secret-with-labels-config", "spring.main.cloud-platform=KUBERNETES",
+				"spring.config.import=kubernetes:,classpath:./secret-with-labels-config.yaml" })
+@EnableKubernetesMockClient(crud = true, https = false)
+class ConfigDataSecretsWithLabelsTests extends SecretsWithLabelsTests {
+
+	private static KubernetesClient mockClient;
+
+	@BeforeAll
+	static void setUpBeforeClass() {
+		setUpBeforeClass(mockClient);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/One.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/One.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.secrets_with_labels;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("secret")
+class One {
+
+	private String property;
+
+	String getProperty() {
+		return property;
+	}
+
+	void setProperty(String property) {
+		this.property = property;
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsApp.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsApp.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.secrets_with_labels;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties({ One.class })
+class SecretsWithLabelsApp {
+
+	static void main(String[] args) {
+		SpringApplication.run(SecretsWithLabelsApp.class, args);
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsController.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.secrets_with_labels;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class SecretsWithLabelsController {
+
+	private final One one;
+
+	SecretsWithLabelsController(One one) {
+		this.one = one;
+	}
+
+	@GetMapping("secrets/labels/one")
+	String one() {
+		return one.getProperty();
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsTests.java
@@ -24,32 +24,24 @@ import java.util.Map;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SecretsWithLabelsApp.class,
-		properties = { "spring.cloud.bootstrap.name=secret-with-labels-config",
-				"spring.main.cloud-platform=KUBERNETES" })
-@EnableKubernetesMockClient(crud = true, https = false)
-class SecretsWithLabelsTests {
+abstract class SecretsWithLabelsTests {
 
 	private static KubernetesClient mockClient;
 
 	@Autowired
 	private WebTestClient webClient;
 
-	@BeforeAll
-	static void setUpBeforeClass() {
-
+	static void setUpBeforeClass(KubernetesClient mockClient) {
+		SecretsWithLabelsTests.mockClient = mockClient;
 		// Configure the kubernetes master url to point to the mock server
 		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
 		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");

--- a/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsTests.java
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/java/org/springframework/cloud/kubernetes/fabric8/config/secrets_with_labels/SecretsWithLabelsTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.kubernetes.fabric8.config.secrets_with_labels;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * @author wind57
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = SecretsWithLabelsApp.class,
+		properties = { "spring.cloud.bootstrap.name=secret-with-labels-config",
+				"spring.main.cloud-platform=KUBERNETES" })
+@EnableKubernetesMockClient(crud = true, https = false)
+class SecretsWithLabelsTests {
+
+	private static KubernetesClient mockClient;
+
+	@Autowired
+	private WebTestClient webClient;
+
+	@BeforeAll
+	static void setUpBeforeClass() {
+
+		// Configure the kubernetes master url to point to the mock server
+		System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, mockClient.getConfiguration().getMasterUrl());
+		System.setProperty(Config.KUBERNETES_TRUST_CERT_SYSTEM_PROPERTY, "true");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_AUTH_TRYSERVICEACCOUNT_SYSTEM_PROPERTY, "false");
+		System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, "test");
+		System.setProperty(Config.KUBERNETES_HTTP2_DISABLE, "true");
+
+		Map<String, String> two = Collections.singletonMap("secret.property",
+				Base64.getEncoder().encodeToString("value".getBytes(StandardCharsets.UTF_8)));
+		createSecret("secret-two", two);
+
+		Map<String, String> three = Collections.singletonMap("secret.property",
+				Base64.getEncoder().encodeToString("diff-value".getBytes(StandardCharsets.UTF_8)));
+		createSecret("secret-three", three);
+
+	}
+
+	private static void createSecret(String name, Map<String, String> data) {
+		mockClient.secrets().inNamespace("spring-k8s")
+				.create(new SecretBuilder().withNewMetadata().withName(name).endMetadata().addToData(data).build());
+	}
+
+	/**
+	 * <pre>
+	 *	 1. We have two secrets in a certain namespace: "secret-two" and "secret-three".
+	 *	 2. Both of the above configure the same secret data: "secret.property", but with different
+	 *	    values : "value" and "diff-value"
+	 *	 3. In our configuration we want to read only "secret-two" (the one that stores "value" inside)
+	 *	 4. This test proves that we do not touch "secret-three"
+	 * </pre>
+	 */
+	@Test
+	void testOne() {
+		this.webClient.get().uri("secrets/labels/one").exchange().expectStatus().isOk().expectBody(String.class)
+				.value(Matchers.equalTo("value"));
+	}
+
+}

--- a/spring-cloud-kubernetes-fabric8-config/src/test/resources/application-with-active-profiles-name.yaml
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/resources/application-with-active-profiles-name.yaml
@@ -1,4 +1,6 @@
 spring:
-  profiles: development
+  config:
+    activate:
+      on-profile: development
 bean:
   greeting: "Hello ConfigMap Active Profile Name, %s!"

--- a/spring-cloud-kubernetes-fabric8-config/src/test/resources/application-with-profiles.yaml
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/resources/application-with-profiles.yaml
@@ -3,16 +3,22 @@ bean:
   farewell: "Goodbye ConfigMap default, %s!"
 ---
 spring:
-  profiles: development
+  config:
+    activate:
+      on-profile: development
 bean:
   greeting: "Hello ConfigMap dev, %s!"
 ---
 spring:
-  profiles: production
+  config:
+    activate:
+      on-profile: production
 bean:
   greeting: "Hello ConfigMap prod, %s!"
 ---
 spring:
-  profiles: production & us-east
+  config:
+    activate:
+      on-profile: production & us-east
 bean:
   greeting: "Hello ConfigMap production and us-east, %s!"

--- a/spring-cloud-kubernetes-fabric8-config/src/test/resources/secret-with-labels-config.yaml
+++ b/spring-cloud-kubernetes-fabric8-config/src/test/resources/secret-with-labels-config.yaml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: with-prefix
+  cloud:
+    kubernetes:
+      secrets:
+        enableApi: true
+        namespace: spring-k8s
+        sources:
+          - name: secret-two

--- a/spring-cloud-kubernetes-fabric8-istio/src/test/java/org/springframework/cloud/kubernetes/fabric8/istio/IstioAutoConfigurationClientNotPresentWhenKubernetesDisabled.java
+++ b/spring-cloud-kubernetes-fabric8-istio/src/test/java/org/springframework/cloud/kubernetes/fabric8/istio/IstioAutoConfigurationClientNotPresentWhenKubernetesDisabled.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author wind57
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class,
-		properties = { "spring.cloud.kubernetes.enabled=false" })
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = App.class)
 class IstioAutoConfigurationClientNotPresentWhenKubernetesDisabled {
 
 	@Autowired


### PR DESCRIPTION
This is a daunting change, but nearly all the changes are related to modifying tests to cover both Bootstrap and ConfigData methods of loading configuration.  The crux of the changes are in 
KubernetesConfigDataLoader
KubernetesConfigDataLocationResolver
KubernetesConfigDataResource
KubernetesClientConfigDataLocationResolver - Kubernetes Java client implementation
Fabric8SecretsPropertySourceLocator - Fabric8 implementation
