### PR TITLE
Add possibility to disable configmap creation

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -86,6 +86,7 @@
 |spring.cloud.kubernetes.leader.publish-failed-events | `+++false+++` | Enable/disable publishing events in case leadership acquisition fails. Default: false
 |spring.cloud.kubernetes.leader.role |  | Role for which leadership this candidate will compete.
 |spring.cloud.kubernetes.leader.update-period | `+++60000ms+++` | Leadership status check period. Default: 60s
+|spring.cloud.kubernetes.leader.create-config-map | `+++true+++` | Enable/disable creating ConfigMap if it does not exist. Default: true
 |spring.cloud.kubernetes.loadbalancer.cluster-domain | `+++cluster.local+++` | cluster domain.
 |spring.cloud.kubernetes.loadbalancer.enabled | `+++true+++` | Load balancer enabled,default true.
 |spring.cloud.kubernetes.loadbalancer.mode |  | {@link KubernetesLoadBalancerMode} setting load balancer server list with ip of pod or service name. default value is POD.

--- a/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/leader/LeaderProperties.java
+++ b/spring-cloud-kubernetes-commons/src/main/java/org/springframework/cloud/kubernetes/commons/leader/LeaderProperties.java
@@ -38,6 +38,8 @@ public class LeaderProperties {
 
 	private static final boolean DEFAULT_PUBLISH_FAILED_EVENTS = false;
 
+	private static final boolean DEFAULT_CREATE_CONFIG_MAP = true;
+
 	/**
 	 * Should leader election be enabled. Default: true
 	 */
@@ -78,6 +80,11 @@ public class LeaderProperties {
 	 * false
 	 */
 	private boolean publishFailedEvents = DEFAULT_PUBLISH_FAILED_EVENTS;
+
+	/**
+	 * Enable/disable creating ConfigMap if it does not exist. Default: true
+	 */
+	private boolean createConfigMap = DEFAULT_CREATE_CONFIG_MAP;
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -149,6 +156,14 @@ public class LeaderProperties {
 
 	public void setPublishFailedEvents(boolean publishFailedEvents) {
 		this.publishFailedEvents = publishFailedEvents;
+	}
+
+	public boolean isCreateConfigMap() {
+		return this.createConfigMap;
+	}
+
+	public void setCreateConfigMap(boolean createConfigMap) {
+		this.createConfigMap = createConfigMap;
 	}
 
 }

--- a/spring-cloud-kubernetes-fabric8-leader/src/main/java/org/springframework/cloud/kubernetes/fabric8/leader/Fabric8LeadershipController.java
+++ b/spring-cloud-kubernetes-fabric8-leader/src/main/java/org/springframework/cloud/kubernetes/fabric8/leader/Fabric8LeadershipController.java
@@ -98,7 +98,7 @@ public class Fabric8LeadershipController extends LeadershipController {
 
 		try {
 			Map<String, String> data = getLeaderData(this.candidate);
-			if (configMap == null) {
+			if (configMap == null && leaderProperties.isCreateConfigMap()) {
 				createConfigMap(data);
 			}
 			else {

--- a/spring-cloud-kubernetes-fabric8-leader/src/main/java/org/springframework/cloud/kubernetes/fabric8/leader/Fabric8LeadershipController.java
+++ b/spring-cloud-kubernetes-fabric8-leader/src/main/java/org/springframework/cloud/kubernetes/fabric8/leader/Fabric8LeadershipController.java
@@ -51,6 +51,12 @@ public class Fabric8LeadershipController extends LeadershipController {
 	public synchronized void update() {
 		LOGGER.debug("Checking leader state");
 		ConfigMap configMap = getConfigMap();
+		if (configMap == null && !leaderProperties.isCreateConfigMap()) {
+			LOGGER.warn("ConfigMap '{}' does not exist and leaderProperties.isCreateConfigMap() "
+					+ "is false, cannot acquire leadership", leaderProperties.getConfigMapName());
+			notifyOnFailedToAcquire();
+			return;
+		}
 		Leader leader = extractLeader(configMap);
 
 		if (leader != null && isPodReady(leader.getId())) {
@@ -98,7 +104,8 @@ public class Fabric8LeadershipController extends LeadershipController {
 
 		try {
 			Map<String, String> data = getLeaderData(this.candidate);
-			if (configMap == null && leaderProperties.isCreateConfigMap()) {
+
+			if (configMap == null) {
 				createConfigMap(data);
 			}
 			else {


### PR DESCRIPTION
As configmaps are sometimes managed by different parties (in our case it is a Helmchart that takes care of creating and destroying configmaps), it would be helpful to have a possibility to disable leader configmap creation on the library's side.