### PR TITLE
Remove redundant dependencies

### DIFF
--- a/spring-cloud-kubernetes-commons/pom.xml
+++ b/spring-cloud-kubernetes-commons/pom.xml
@@ -63,7 +63,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.retry</groupId>

--- a/spring-cloud-kubernetes-commons/pom.xml
+++ b/spring-cloud-kubernetes-commons/pom.xml
@@ -34,10 +34,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-logging</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-actuator-autoconfigure</artifactId>
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION
There are two `spring-boot-starter-logging dependencies` in `spring-cloud-kubernetes-commons`，We could remove one