### PR TITLE
fix issue 870 - make spring-boot-starter-logging optional

### DIFF
--- a/spring-cloud-kubernetes-commons/pom.xml
+++ b/spring-cloud-kubernetes-commons/pom.xml
@@ -63,6 +63,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.retry</groupId>


### PR DESCRIPTION
This fixes #870 . It makes `spring-boot-starter-logging` optional.