### PR TITLE
Fix properties retrieval order from configmaps

### DIFF
--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/main/java/org/springframework/cloud/kubernetes/configserver/KubernetesEnvironmentRepository.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/main/java/org/springframework/cloud/kubernetes/configserver/KubernetesEnvironmentRepository.java
@@ -64,10 +64,10 @@ public class KubernetesEnvironmentRepository implements EnvironmentRepository {
 		try {
 			StandardEnvironment springEnv = new StandardEnvironment();
 			springEnv.setActiveProfiles(profiles);
-			addApplicationConfiguration(environment, springEnv, "application");
 			if (!"application".equalsIgnoreCase(application)) {
 				addApplicationConfiguration(environment, springEnv, application);
 			}
+			addApplicationConfiguration(environment, springEnv, "application");
 			return environment;
 		}
 		catch (Exception e) {

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/KubernetesEnvironmentRepositoryTests.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/KubernetesEnvironmentRepositoryTests.java
@@ -244,4 +244,29 @@ class KubernetesEnvironmentRepositoryTests {
 		});
 	}
 
+	@Test
+	public void testApplicationPropertiesAnSecretsOverride() throws ApiException {
+		CoreV1Api coreApi = mock(CoreV1Api.class);
+		when(coreApi.listNamespacedConfigMap(eq("default"), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null),
+			eq(null), eq(null), eq(null), eq(null))).thenReturn(CONFIGMAP_DEFAULT_LIST);
+		when(coreApi.listNamespacedSecret(eq("default"), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null),
+			eq(null), eq(null), eq(null), eq(null))).thenReturn(SECRET_LIST);
+		when(coreApi.listNamespacedConfigMap(eq("dev"), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null),
+			eq(null), eq(null), eq(null), eq(null))).thenReturn(CONFIGMAP_DEV_LIST);
+		KubernetesEnvironmentRepository environmentRepository = new KubernetesEnvironmentRepository(coreApi,
+			kubernetesPropertySourceSuppliers, "default");
+		Environment environment = environmentRepository.findOne("stores-dev", "", "");
+		environment.getPropertySources().stream().filter(propertySource -> propertySource.getName().startsWith("configmap")).reduce((first, second) -> second).ifPresent(propertySource -> {
+			assertThat(propertySource.getName()).isEqualTo("configmap.application.default");
+		});
+		environment.getPropertySources().stream().filter(propertySource -> propertySource.getName().startsWith("configmap")).findFirst().ifPresent(propertySource -> {
+			assertThat(propertySource.getSource().get("dummy.property.int2")).isEqualTo(2);
+			assertThat(propertySource.getSource().get("dummy.property.bool2")).isEqualTo(false);
+			assertThat(propertySource.getSource().get("dummy.property.string2")).isEqualTo("b");
+		});
+		environment.getPropertySources().stream().filter(propertySource -> propertySource.getName().startsWith("secrets")).findFirst().ifPresent(propertySource -> {
+			assertThat(propertySource.getSource().get("username")).isEqualTo("stores-dev");
+			assertThat(propertySource.getSource().get("password")).isEqualTo("p455w0rd");
+		});
+	}
 }


### PR DESCRIPTION
The properties defined by the configmap "application" should be the last in the environment list, so you can always override the properties values by profile and by application