### PR TITLE
#1363: make Mockito dependency test-scoped instead of compile-scoped

### DIFF
--- a/spring-cloud-kubernetes-fabric8-discovery/pom.xml
+++ b/spring-cloud-kubernetes-fabric8-discovery/pom.xml
@@ -60,6 +60,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Fixes #1363.  Pretty self-explanatory otherwise.