### PR TITLE
Clarify k8s ConfigMap property source instructions

### DIFF
--- a/docs/modules/ROOT/pages/property-source-config.adoc
+++ b/docs/modules/ROOT/pages/property-source-config.adoc
@@ -7,7 +7,7 @@ an `application-profile.properties` or `application-profile.yaml` file that cont
 application or Spring Boot starters. You can override these properties by specifying system properties or environment
 variables.
 
-To enable this functionality you need to set `spring.config.import=kubernetes:` in your application's configuration properties.
+To enable this functionality you need to set the `spring.config.import` application configuration property to `kubernetes:` (escape with quotes when using yaml eg. `"kubernetes:"`).
 Currently you can not specify a ConfigMap or Secret to load using `spring.config.import`, by default Spring Cloud Kubernetes
 will load a ConfigMap and/or Secret based on the `spring.application.name` property.  If `spring.application.name` is not set it will
 load a ConfigMap and/or Secret with the name `application`.
@@ -15,4 +15,3 @@ load a ConfigMap and/or Secret with the name `application`.
 If you would like to load Kubernetes ``PropertySource``s during the bootstrap phase like it worked prior to the 3.0.x release
 you can either add `spring-cloud-starter-bootstrap` to your application's classpath or set `spring.cloud.bootstrap.enabled=true`
 as an environment variable.
-


### PR DESCRIPTION
This commit updates the property-source-config.adoc to clarify the need to escape the "kubernetes:" value for the 'spring.config.import' property.