### PR TITLE
discoveryserver: fixes deployment yaml and adds notes about use of Eureka's port

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-kubernetes-discoveryserver.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-kubernetes-discoveryserver.adoc
@@ -8,9 +8,9 @@ the `DiscoveryClient` implementation provided by that starter.
 
 ## Permissions
 The Spring Cloud Discovery server uses
-the Kubernetes API server to get data about Service and Endpoint resources so it needs list, watch, and
-get permissions to use those endpoints.  See the below sample Kubernetes deployment YAML for an
-example of how to configure the Service Account on Kubernetes.
+the Kubernetes API server to get data about Pod, Service and Endpoint resources, so it needs list,
+watch, and get permissions to use those endpoints.  See the below sample Kubernetes deployment YAML
+for an example of how to configure the Service Account on Kubernetes.
 
 
 ## Endpoints
@@ -171,7 +171,7 @@ items:
       name: namespace-reader
     rules:
       - apiGroups: ["", "extensions", "apps"]
-        resources: ["services", "endpoints"]
+        resources: ["pods", "services", "endpoints"]
         verbs: ["get", "list", "watch"]
   - apiVersion: apps/v1
     kind: Deployment
@@ -186,10 +186,10 @@ items:
           labels:
             app: spring-cloud-kubernetes-discoveryserver
         spec:
-          serviceAccount: spring-cloud-kubernetes-discoveryserver
+          serviceAccountName: spring-cloud-kubernetes-discoveryserver
           containers:
           - name: spring-cloud-kubernetes-discoveryserver
-            image: springcloud/spring-cloud-kubernetes-discoveryserver:3.0.0-SNAPSHOT
+            image: springcloud/spring-cloud-kubernetes-discoveryserver:3.1.0
             imagePullPolicy: IfNotPresent
             readinessProbe:
               httpGet:
@@ -204,3 +204,7 @@ items:
 
 
 ----
+
+*Note* While the port is the same as Eureka's default (8761), there is no conflict despite the JSON
+returned being in a different format. Conflicts are avoided due to the spring-cloud-discoveryserver
+API being mounted at the HTTP path '/apps', not '/eureka/v2/apps'.

--- a/docs/modules/ROOT/pages/spring-cloud-kubernetes-discoveryserver.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-kubernetes-discoveryserver.adoc
@@ -204,7 +204,3 @@ items:
 
 
 ----
-
-*Note* While the port is the same as Eureka's default (8761), there is no conflict despite the JSON
-returned being in a different format. Conflicts are avoided due to the spring-cloud-discoveryserver
-API being mounted at the HTTP path '/apps', not '/eureka/v2/apps'.


### PR DESCRIPTION
tried the docs, which drifted a bit.


Note: My brain broke about why this is using the same port as eureka. It seems it was an arbitrary choice, not a transition story. So, I didn't document anything about that.