### PR TITLE
Replaces manual workaround for Paketo with Maven profile

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-kubernetes.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-kubernetes.adoc
@@ -35,20 +35,6 @@ To see the list of all Kubernetes related configuration properties please check 
 Click https://docs.spring.io/spring-cloud-build/reference/building.html[here] for basic building instructions.
 
 
-[[building-docker-images-on-arm64]]
-=== Building Docker Images On ARM64
-
-If you run the Spring Cloud Kuberentes build on an ARM64 machine the docker images
-used for the integration tests will fail to run due to using the wrong architecture.
-This is because the Paketo build pack does not yet support ARM64.  To work around this you
-can run the build by passing `-Dspring-boot.build-image.builder=dashaun/builder:tiny` to Maven.
-
-For example:
-```
-./mvnw clean install -Dspring-boot.build-image.builder=dashaun/builder:tiny
-```
-
-
 [[contributing]]
 == Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -376,5 +376,18 @@
 				</plugins>
 			</build>
 		</profile>
+		<!-- Workaround until Paketo build packs support arm64 a.k.a. aarch64
+		     See https://github.com/buildpacks/pack/issues?q=is%3Aissue+is%3Aopen+arm64 -->
+		<profile>
+			<id>build-image-aarch64</id>
+			<activation>
+				<os>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<spring-boot.build-image.builder>dashaun/builder:tiny</spring-boot.build-image.builder>
+			</properties>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
The former process is too easy to forget and doesn't error either.