### PR TITLE
Update Kubernetes client deps

### DIFF
--- a/spring-cloud-kubernetes-dependencies/pom.xml
+++ b/spring-cloud-kubernetes-dependencies/pom.xml
@@ -33,8 +33,8 @@
 	<description>Spring Cloud Kubernetes Dependencies</description>
 	<properties>
 		<kubernetes-fabric8-client.version>6.13.4</kubernetes-fabric8-client.version>
-		<kubernetes-native-client.version>19.0.1</kubernetes-native-client.version>
-		<wiremock.version>3.4.2</wiremock.version>
+		<kubernetes-native-client.version>22.0.0</kubernetes-native-client.version>
+		<wiremock.version>3.9.2</wiremock.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Avoids inconsistency with Spring Boot 3.4.0 which requires gson 2.11.x due to the `com.google.gson.Strictness`