### PR TITLE
Add Maven profile for Vault integration

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-kubernetes-configserver.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-kubernetes-configserver.adoc
@@ -29,6 +29,14 @@ list of namespace values.
 NOTE: If you set `spring.cloud.kubernetes.configserver.config-map-namespaces` and/or `spring.cloud.kubernetes.configserver.secrets-namespaces`
 you will need to include the namespace in which the Config Server is deployed in order to continue to fetch Config Map and Secret data from that namespace.
 
+### Vault Integration
+To enable Vault integration, you can activate the vault Maven profile by setting the `useVault` property to true. This profile adds the `spring-vault-core` dependency.
+
+Example:
+```bash
+mvn clean install -DuseVault=true
+``` 
+
 ### Kubernetes Access Controls
 The Kubernetes Config Server uses the Kubernetes API server to fetch Config Map and Secret data.  In order for it to do that
 it needs ability to `get` and `list` Config Map and Secrets (depending on what you enable/disable).

--- a/docs/modules/ROOT/pages/spring-cloud-kubernetes-configserver.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-kubernetes-configserver.adoc
@@ -29,13 +29,13 @@ list of namespace values.
 NOTE: If you set `spring.cloud.kubernetes.configserver.config-map-namespaces` and/or `spring.cloud.kubernetes.configserver.secrets-namespaces`
 you will need to include the namespace in which the Config Server is deployed in order to continue to fetch Config Map and Secret data from that namespace.
 
-### Vault Integration
-To enable Vault integration, you can activate the vault Maven profile by setting the `useVault` property to true. This profile adds the `spring-vault-core` dependency.
+### Using Advanced Features Of Spring Vault
+In order to use some of the [more advanced Spring Vault features](https://docs.spring.io/spring-cloud-config/reference/server/environment-repository/vault-backend.html) of the **Spring Cloud Config Server**, [`spring-vault-core`](https://mvnrepository.com/artifact/org.springframework.vault/spring-vault-core) must be on the classpath. By default, Spring Cloud Kubernetes can generate a Docker image for deploying Config Server to Kubernetes, but it does not include `spring-vault-core` in the classpath. If you need `spring-core-vault` to enable certain functionality in the Config Server you can build your own version of Docker image by enabling the `vault` Maven profile when running Maven build.
 
 Example:
 ```bash
-mvn clean install -DuseVault=true
-``` 
+$ ../../mvnw clean install -Pvault
+```
 
 ### Kubernetes Access Controls
 The Kubernetes Config Server uses the Kubernetes API server to fetch Config Map and Secret data.  In order for it to do that

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/pom.xml
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/pom.xml
@@ -94,12 +94,6 @@
 		</profile>
 		<profile>
 			<id>vault</id>
-			<activation>
-				<property>
-					<name>useVault</name>
-					<value>true</value>
-				</property>
-			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>org.springframework.vault</groupId>

--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/pom.xml
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/pom.xml
@@ -92,6 +92,21 @@
 				<env.IMAGE>springcloud/${project.artifactId}:${project.version}</env.IMAGE>
 			</properties>
 		</profile>
+		<profile>
+			<id>vault</id>
+			<activation>
+				<property>
+					<name>useVault</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.springframework.vault</groupId>
+					<artifactId>spring-vault-core</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
- Add Maven profile `useVault` which adds Spring Vault Core dependency to enable Vault integration in the Spring Cloud Kubernetes Config Server.