### PR TITLE
Specify okhttp dependency

### DIFF
--- a/spring-cloud-kubernetes-fabric8-autoconfig/pom.xml
+++ b/spring-cloud-kubernetes-fabric8-autoconfig/pom.xml
@@ -49,6 +49,17 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-kubernetes-commons</artifactId>
 		</dependency>
+		<!-- Spring Boot removed its dependency management of okhttp in Spring Boot 3.4.0 -->
+		<!-- This resulted in a different version fo okhttp in Spring Cloud 2024.0.0 -->
+		<!-- Spring Cloud is now managing the okhttp dependency version in Spring Cloud Commons -->
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>logging-interceptor</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>

--- a/spring-cloud-kubernetes-fabric8-leader/pom.xml
+++ b/spring-cloud-kubernetes-fabric8-leader/pom.xml
@@ -67,10 +67,5 @@
 			<artifactId>spring-cloud-kubernetes-test-support</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-kubernetes-test-support</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This is needed since Spring Boot no longer manages the version.  The version is managed in Spring Cloud Commons.  See https://github.com/spring-cloud/spring-cloud-commons/pull/1470. Fixes #1813