### PR TITLE
Keep the original JAR when repackaging (#1456)

### DIFF
--- a/spring-cloud-kubernetes-controllers/pom.xml
+++ b/spring-cloud-kubernetes-controllers/pom.xml
@@ -44,6 +44,17 @@
 						<goals>
 							<goal>repackage</goal>
 						</goals>
+						<configuration>
+							<classifier>exec</classifier>
+						</configuration>
+					</execution>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<classifier>exec</classifier>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Fix for #1456
Added a classifier for the 'repackage' execution defined here and also for the 'default' execution defined in the spring-cloud-build parent pom.

New PR agains branch 3.1.x as suggested in #1888 