### PR TITLE
Narrow scope of static mocking that breaks Netty 4.2

### DIFF
--- a/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/ActuatorEnabledFailFastExceptionTest.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/ActuatorEnabledFailFastExceptionTest.java
@@ -74,7 +74,7 @@ class ActuatorEnabledFailFastExceptionTest {
 
 	private static void mocks() {
 		envReaderMockedStatic = Mockito.mockStatic(EnvReader.class);
-		pathsMockedStatic = Mockito.mockStatic(Paths.class);
+		pathsMockedStatic = Mockito.mockStatic(Paths.class, Mockito.CALLS_REAL_METHODS);
 
 		envReaderMockedStatic.when(() -> EnvReader.getEnv(KubernetesClientPodUtils.KUBERNETES_SERVICE_HOST))
 			.thenReturn("k8s-host");

--- a/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/ActuatorEnabledNoFailFastExceptionTest.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/ActuatorEnabledNoFailFastExceptionTest.java
@@ -77,7 +77,7 @@ class ActuatorEnabledNoFailFastExceptionTest {
 
 	private static void mocks() {
 		envReaderMockedStatic = Mockito.mockStatic(EnvReader.class);
-		pathsMockedStatic = Mockito.mockStatic(Paths.class);
+		pathsMockedStatic = Mockito.mockStatic(Paths.class, Mockito.CALLS_REAL_METHODS);
 
 		envReaderMockedStatic.when(() -> EnvReader.getEnv(KubernetesClientPodUtils.KUBERNETES_SERVICE_HOST))
 			.thenReturn("k8s-host");


### PR DESCRIPTION
Mocking `Paths` completely caused some methods to return `null` which breaks Netty's `io.netty.util.internal.PlatformDependent`. Using `CALLS_REAL_METHODS` narrows the effects of the mocking as any methods calls without expectations now call the real methods instead of returning `null`.