### PR TITLE
Fix flakiness in KubernetesEnvironmentRepositoryTests

### DIFF
--- a/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/KubernetesEnvironmentRepositoryTests.java
+++ b/spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver/src/test/java/org/springframework/cloud/kubernetes/configserver/KubernetesEnvironmentRepositoryTests.java
@@ -118,6 +118,7 @@ class KubernetesEnvironmentRepositoryTests {
 
 	@BeforeAll
 	static void before() {
+		KUBERNETES_PROPERTY_SOURCE_SUPPLIER.clear();
 		KUBERNETES_PROPERTY_SOURCE_SUPPLIER.add((coreApi, applicationName, namespace, springEnv) -> {
 			List<MapPropertySource> propertySources = new ArrayList<>();
 


### PR DESCRIPTION
Title:

Fix flakiness in KubernetesEnvironmentRepositoryTests.testApplicationCase

Description:
This PR stabilizes the test KubernetesEnvironmentRepositoryTests.testApplicationCase in the module
spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver.

Root cause

The test became order-dependent (OD) because static suppliers in KUBERNETES_PROPERTY_SOURCE_SUPPLIER
were not properly reset between runs.
When tests were executed in a different order (e.g., by iDFlakies or random test execution),
previous state could leak into the next test, causing unexpected property source configurations.

Fix summary

Added explicit clearing of KUBERNETES_PROPERTY_SOURCE_SUPPLIER in @BeforeAll
to ensure a consistent and isolated environment across test executions.

Verified that the test now passes under randomized order (iDFlakies random-class-method)
and no longer produces inconsistent results.

Verification

Reproduced original order-dependent failure using iDFlakies.

After the fix, all baseline and randomized rounds passed successfully.
## 🧪 Reproduction Script

The following script reproduces the original order-dependent behavior using iDFlakies 2.0.1-SNAPSHOT.  
It also demonstrates how the flaky test `BootstrapConfigServerIntegrationTests#enabled()`  
prevents iDFlakies from establishing a passing baseline, and how removing it allows successful detection.

<details>
<summary>Click to expand the full script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

# Root directory of the spring-cloud-kubernetes repo.
# You can override this by exporting REPO_DIR before running the script.
REPO_DIR="${REPO_DIR:-$HOME/myRepo/spring-cloud-kubernetes}"

# Where we store logs for this run.
LOG_DIR="${LOG_DIR:-$HOME/logs/logs_kuber}"
mkdir -p "$LOG_DIR"

TS="$(date +%Y%m%d-%H%M%S)"
LOG_FILE="${LOG_DIR}/kuber-configserver-idflakies-${TS}.log"

# The module we want to run iDFlakies on.
TARGET_MODULE="spring-cloud-kubernetes-controllers/spring-cloud-kubernetes-configserver"

# iDFlakies version and number of randomization rounds.
IDFLAKIES_VER="${IDFLAKIES_VER:-2.0.1-SNAPSHOT}"
ROUNDS="${ROUNDS:-10}"

# This is the integration test that makes iDFlakies fail to establish a passing baseline.
# When iDFlakies tries to run the original test order 3 times in the same JVM,
# this IT fails to load the Spring test ApplicationContext and the plugin throws
# `NoPassingOrderException`. Because of that, we remove it from the original-order file
# after the first detect run.
BAD_LINE="org.springframework.cloud.kubernetes.configserver.it.BootstrapConfigServerIntegrationTests#enabled()"
# Some iDFlakies runs write the method name without parentheses, so we handle both.
BAD_LINE_NO_PAREN="org.springframework.cloud.kubernetes.configserver.it.BootstrapConfigServerIntegrationTests#enabled"

echo "==== run $(date) ====" | tee "$LOG_FILE"
cd "$REPO_DIR"

# 1) Clean previous artifacts for this module.
echo "[clean]" | tee -a "$LOG_FILE"
rm -rf "$REPO_DIR/$TARGET_MODULE/.dtfixingtools" \
       "$REPO_DIR/$TARGET_MODULE/target" \
       "$REPO_DIR/$TARGET_MODULE/.surefire-*"

# 2) Build the target module without running tests.
echo "[build]" | tee -a "$LOG_FILE"
./mvnw -pl "$TARGET_MODULE" -am clean install \
  -Dmaven.test.skip=true -Dcheckstyle.skip=true -Denforcer.skip=true \
  | tee -a "$LOG_FILE"

# 3) First iDFlakies detect run (may fail with NoPassingOrderException, that's OK).
set +e
./mvnw -pl "$TARGET_MODULE" \
  edu.illinois.cs:idflakies-maven-plugin:${IDFLAKIES_VER}:detect \
  -Ddetector.detector_type=random-class-method \
  -Ddt.randomize.rounds=${ROUNDS} \
  | tee -a "$LOG_FILE"
set -e

# 4) Patch the original-order file.
ORIG_FILE="$REPO_DIR/$TARGET_MODULE/.dtfixingtools/original-order"
if [ -f "$ORIG_FILE" ]; then
  echo "[patch] removing bad IT from $ORIG_FILE" | tee -a "$LOG_FILE"
  grep -v "$BAD_LINE" "$ORIG_FILE" | grep -v "$BAD_LINE_NO_PAREN" > "${ORIG_FILE}.tmp" || true
  mv "${ORIG_FILE}.tmp" "$ORIG_FILE"
else
  echo "[patch] WARN: $ORIG_FILE not found" | tee -a "$LOG_FILE"
fi

# 5) Second iDFlakies detect run (should succeed now).
./mvnw -pl "$TARGET_MODULE" \
  edu.illinois.cs:idflakies-maven-plugin:${IDFLAKIES_VER}:detect \
  -Ddetector.detector_type=random-class-method \
  -Ddt.randomize.rounds=${ROUNDS} \
  -Ddt.detector.original_order.all_must_pass=false \
  | tee -a "$LOG_FILE"

echo "[done] log: $LOG_FILE" | tee -a "$LOG_FILE"