### PR TITLE
fixes label selector generation for Kubernetes client requests

### DIFF
--- a/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/KubernetesClientUtils.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/main/java/org/springframework/cloud/kubernetes/client/KubernetesClientUtils.java
@@ -115,7 +115,10 @@ public final class KubernetesClientUtils {
 	}
 
 	public static String labelSelector(Map<String, String> labels) {
-		return labels.entrySet().stream().map(en -> en.getKey() + "=" + en.getValue()).collect(Collectors.joining("&"));
+		if (labels == null || labels.isEmpty()) {
+			return null;
+		}
+		return labels.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(","));
 	}
 
 }

--- a/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/KubernetesClientUtilsTests.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/KubernetesClientUtilsTests.java
@@ -68,7 +68,13 @@ class KubernetesClientUtilsTests {
 	}
 
 	@Test
-	void multipleLabelsLabel() {
+	void testNull() {
+		String result = KubernetesClientUtils.labelSelector(null);
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void multipleLabels() {
 		Map<String, String> labels = new LinkedHashMap<>();
 		labels.put("a", "b");
 		labels.put("c", "d");

--- a/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/KubernetesClientUtilsTests.java
+++ b/spring-cloud-kubernetes-client-autoconfig/src/test/java/org/springframework/cloud/kubernetes/client/KubernetesClientUtilsTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.kubernetes.client;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -49,6 +53,27 @@ class KubernetesClientUtilsTests {
 	void testNamespaceResolutionFailed() {
 		assertThatThrownBy(() -> KubernetesClientUtils.getApplicationNamespace("", "target", null))
 			.isInstanceOf(NamespaceResolutionFailedException.class);
+	}
+
+	@Test
+	void emptyLabels() {
+		String result = KubernetesClientUtils.labelSelector(Map.of());
+		Assertions.assertThat(result).isNull();
+	}
+
+	@Test
+	void singleLabel() {
+		String result = KubernetesClientUtils.labelSelector(Map.of("a", "b"));
+		Assertions.assertThat(result).isEqualTo("a=b");
+	}
+
+	@Test
+	void multipleLabelsLabel() {
+		Map<String, String> labels = new LinkedHashMap<>();
+		labels.put("a", "b");
+		labels.put("c", "d");
+		String result = KubernetesClientUtils.labelSelector(labels);
+		Assertions.assertThat(result).isEqualTo("a=b,c=d");
 	}
 
 }

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/LabeledSecretContextToSourceDataProviderSingleReadTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/LabeledSecretContextToSourceDataProviderSingleReadTests.java
@@ -141,8 +141,8 @@ class LabeledSecretContextToSourceDataProviderSingleReadTests {
 		V1SecretList secretList = new V1SecretList().addItemsItem(red);
 
 		String selector = "label2=value2,label1=value1";
-		String path = "/api/v1/namespaces/default/secrets?labelSelector=" +
-			URLEncoder.encode(selector, StandardCharsets.UTF_8);
+		String path = "/api/v1/namespaces/default/secrets?labelSelector="
+				+ URLEncoder.encode(selector, StandardCharsets.UTF_8);
 		stubCall(secretList, path);
 		CoreV1Api api = new CoreV1Api();
 
@@ -204,8 +204,8 @@ class LabeledSecretContextToSourceDataProviderSingleReadTests {
 		V1SecretList secretList = new V1SecretList().addItemsItem(one);
 
 		String selector = "label2=value2,label1=value1";
-		String path = "/api/v1/namespaces/default/secrets?labelSelector=" +
-			URLEncoder.encode(selector, StandardCharsets.UTF_8);
+		String path = "/api/v1/namespaces/default/secrets?labelSelector="
+				+ URLEncoder.encode(selector, StandardCharsets.UTF_8);
 
 		stubCall(secretList, path);
 		CoreV1Api api = new CoreV1Api();

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/LabeledSecretContextToSourceDataProviderSingleReadTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/LabeledSecretContextToSourceDataProviderSingleReadTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.kubernetes.client.config;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Iterator;
@@ -138,7 +140,10 @@ class LabeledSecretContextToSourceDataProviderSingleReadTests {
 			.build();
 		V1SecretList secretList = new V1SecretList().addItemsItem(red);
 
-		stubCall(secretList, "/api/v1/namespaces/default/secrets?labelSelector=label2%3Dvalue2%26label1%3Dvalue1");
+		String selector = "label2=value2,label1=value1";
+		String path = "/api/v1/namespaces/default/secrets?labelSelector=" +
+			URLEncoder.encode(selector, StandardCharsets.UTF_8);
+		stubCall(secretList, path);
 		CoreV1Api api = new CoreV1Api();
 
 		NormalizedSource source = new LabeledSecretNormalizedSource(NAMESPACE, LABELS, false,
@@ -198,7 +203,11 @@ class LabeledSecretContextToSourceDataProviderSingleReadTests {
 			.build();
 		V1SecretList secretList = new V1SecretList().addItemsItem(one);
 
-		stubCall(secretList, "/api/v1/namespaces/default/secrets?labelSelector=label2%3Dvalue2%26label1%3Dvalue1");
+		String selector = "label2=value2,label1=value1";
+		String path = "/api/v1/namespaces/default/secrets?labelSelector=" +
+			URLEncoder.encode(selector, StandardCharsets.UTF_8);
+
+		stubCall(secretList, path);
 		CoreV1Api api = new CoreV1Api();
 
 		NormalizedSource source = new LabeledSecretNormalizedSource(NAMESPACE + "nope", LABELS, false,

--- a/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/reload/KubernetesClientEventBasedSecretsChangeDetectorTests.java
+++ b/spring-cloud-kubernetes-client-config/src/test/java/org/springframework/cloud/kubernetes/client/config/reload/KubernetesClientEventBasedSecretsChangeDetectorTests.java
@@ -99,16 +99,15 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 		V1SecretList secretList = new V1SecretList().metadata(new V1ListMeta().resourceVersion("1"))
 			.items(List.of(dbPassword));
 
-		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*"))
-			.withQueryParam("watch", equalTo("false"))
+		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*")).withQueryParam("watch", equalTo("false"))
 			.withQueryParam("resourceVersion", equalTo("0"))
 			.willReturn(aResponse().withStatus(200).withBody(JSON.serialize(secretList))));
 
 		// ------------------------------------------------------------------------------------------------------------
 		// 1. first watch response to request with resourceVersion=1
 
-		V1Secret dbPasswordUpdated = new V1Secret().metadata(
-				new V1ObjectMeta().name("db-password").resourceVersion("2"))
+		V1Secret dbPasswordUpdated = new V1Secret()
+			.metadata(new V1ObjectMeta().name("db-password").resourceVersion("2"))
 			.putStringDataItem("password", Base64.getEncoder().encodeToString("p455w0rd2".getBytes()))
 			.putDataItem("password", Base64.getEncoder().encode("p455w0rd2".getBytes()))
 			.putStringDataItem("username", Base64.getEncoder().encodeToString("user".getBytes()))
@@ -116,8 +115,7 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 
 		Response<V1Secret> watchResponse = new Response<>(MODIFIED.name(), dbPasswordUpdated);
 
-		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*"))
-			.withQueryParam("watch", equalTo("true"))
+		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*")).withQueryParam("watch", equalTo("true"))
 			.withQueryParam("resourceVersion", equalTo("1"))
 			.willReturn(aResponse().withStatus(200).withBody(JSON.serialize(watchResponse))));
 
@@ -129,11 +127,9 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 
 		Response<V1Secret> rabbitPasswordAddedResponse = new Response<>(ADDED.name(), rabbitPasswordAdded);
 
-		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*"))
-			.withQueryParam("watch", equalTo("true"))
+		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*")).withQueryParam("watch", equalTo("true"))
 			.withQueryParam("resourceVersion", equalTo("2"))
-			.willReturn(aResponse().withStatus(200)
-				.withBody(JSON.serialize(rabbitPasswordAddedResponse))));
+			.willReturn(aResponse().withStatus(200).withBody(JSON.serialize(rabbitPasswordAddedResponse))));
 
 		// ------------------------------------------------------------------------------------------------------------
 		// 3. third watch response to request with resourceVersion=3
@@ -143,11 +139,9 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 
 		Response<V1Secret> rabbitPasswordDeletedResponse = new Response<>(DELETED.name(), rabbitPasswordDeleted);
 
-		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*"))
-			.withQueryParam("watch", equalTo("true"))
+		stubFor(get(urlMatching("/api/v1/namespaces/default/secrets.*")).withQueryParam("watch", equalTo("true"))
 			.withQueryParam("resourceVersion", equalTo("3"))
-			.willReturn(aResponse().withStatus(200)
-				.withBody(JSON.serialize(rabbitPasswordDeletedResponse))));
+			.willReturn(aResponse().withStatus(200).withBody(JSON.serialize(rabbitPasswordDeletedResponse))));
 
 		// ------------------------------------------------------------------------------------------------------------
 		// 4. assertions
@@ -278,7 +272,7 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 
 		// mock environment
 		KubernetesMockEnvironment environment = new KubernetesMockEnvironment(
-			mock(KubernetesClientSecretsPropertySource.class));
+				mock(KubernetesClientSecretsPropertySource.class));
 
 		// locator
 		KubernetesClientSecretsPropertySourceLocator locator = mock(KubernetesClientSecretsPropertySourceLocator.class);
@@ -287,8 +281,8 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 
 		// properties
 		ConfigReloadProperties properties = new ConfigReloadProperties(false, false, true,
-			ConfigReloadProperties.ReloadStrategy.REFRESH, ConfigReloadProperties.ReloadDetectionMode.EVENT,
-			Duration.ofMillis(15000), Set.of(), false, Duration.ofSeconds(2));
+				ConfigReloadProperties.ReloadStrategy.REFRESH, ConfigReloadProperties.ReloadDetectionMode.EVENT,
+				Duration.ofMillis(15000), Set.of(), false, Duration.ofSeconds(2));
 
 		// namespace provider
 		KubernetesNamespaceProvider kubernetesNamespaceProvider = mock(KubernetesNamespaceProvider.class);
@@ -296,7 +290,7 @@ class KubernetesClientEventBasedSecretsChangeDetectorTests {
 
 		// change detector
 		KubernetesClientEventBasedSecretsChangeDetector changeDetector = new KubernetesClientEventBasedSecretsChangeDetector(
-			coreV1Api, environment, properties, strategy, locator, kubernetesNamespaceProvider);
+				coreV1Api, environment, properties, strategy, locator, kubernetesNamespaceProvider);
 
 		changeDetector.inform();
 

--- a/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientDiscoveryClientUtils.java
+++ b/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientDiscoveryClientUtils.java
@@ -43,6 +43,7 @@ import org.springframework.cloud.kubernetes.commons.discovery.ServiceMetadata;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.util.CollectionUtils;
 
+import static org.springframework.cloud.kubernetes.client.KubernetesClientUtils.labelSelector;
 import static org.springframework.cloud.kubernetes.commons.discovery.DiscoveryClientUtils.poll;
 import static org.springframework.cloud.kubernetes.commons.discovery.KubernetesDiscoveryConstants.UNSET_PORT_NAME;
 import static org.springframework.util.StringUtils.hasText;
@@ -155,13 +156,6 @@ final class KubernetesClientDiscoveryClientUtils {
 			.watch(params.watch)
 			.labelSelector(labelSelector(serviceLabels))
 			.buildCall(null);
-	}
-
-	static String labelSelector(Map<String, String> labels) {
-		if (labels == null || labels.isEmpty()) {
-			return null;
-		}
-		return labels.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(","));
 	}
 
 }

--- a/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientEndpointSlicesCatalogWatch.java
+++ b/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientEndpointSlicesCatalogWatch.java
@@ -35,7 +35,7 @@ import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
 import org.springframework.cloud.kubernetes.commons.discovery.EndpointNameAndNamespace;
 import org.springframework.core.log.LogAccessor;
 
-import static org.springframework.cloud.kubernetes.client.discovery.KubernetesClientDiscoveryClientUtils.labelSelector;
+import static org.springframework.cloud.kubernetes.client.KubernetesClientUtils.labelSelector;
 
 /**
  * Implementation that is based on EndpointSlice V1.

--- a/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientEndpointsCatalogWatch.java
+++ b/spring-cloud-kubernetes-client-discovery/src/main/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientEndpointsCatalogWatch.java
@@ -36,7 +36,7 @@ import org.springframework.cloud.kubernetes.client.KubernetesClientUtils;
 import org.springframework.cloud.kubernetes.commons.discovery.EndpointNameAndNamespace;
 import org.springframework.core.log.LogAccessor;
 
-import static org.springframework.cloud.kubernetes.client.discovery.KubernetesClientDiscoveryClientUtils.labelSelector;
+import static org.springframework.cloud.kubernetes.client.KubernetesClientUtils.labelSelector;
 
 /**
  * Implementation that is based on V1Endpoints.

--- a/spring-cloud-kubernetes-client-discovery/src/test/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientDiscoveryClientUtilsTests.java
+++ b/spring-cloud-kubernetes-client-discovery/src/test/java/org/springframework/cloud/kubernetes/client/discovery/KubernetesClientDiscoveryClientUtilsTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.kubernetes.client.discovery;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -178,27 +177,6 @@ class KubernetesClientDiscoveryClientUtilsTests {
 		List<V1EndpointAddress> addresses = KubernetesClientDiscoveryClientUtils.addresses(endpointSubset, properties);
 		List<String> hostNames = addresses.stream().map(V1EndpointAddress::getHostname).sorted().toList();
 		Assertions.assertThat(hostNames).containsExactly("one", "three", "two");
-	}
-
-	@Test
-	void emptyLabels() {
-		String result = KubernetesClientDiscoveryClientUtils.labelSelector(Map.of());
-		Assertions.assertThat(result).isNull();
-	}
-
-	@Test
-	void singleLabel() {
-		String result = KubernetesClientDiscoveryClientUtils.labelSelector(Map.of("a", "b"));
-		Assertions.assertThat(result).isEqualTo("a=b");
-	}
-
-	@Test
-	void multipleLabelsLabel() {
-		Map<String, String> labels = new LinkedHashMap<>();
-		labels.put("a", "b");
-		labels.put("c", "d");
-		String result = KubernetesClientDiscoveryClientUtils.labelSelector(labels);
-		Assertions.assertThat(result).isEqualTo("a=b,c=d");
 	}
 
 }


### PR DESCRIPTION
This PR fixes label selector generation for Kubernetes client requests by centralizing labelSelector logic in KubernetesClientUtils and updating discovery/config code and tests accordingly.