### PR TITLE
Remove unused asciidoctor-kroki dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "@antora/collector-extension": "1.0.3",
     "@asciidoctor/tabs": "1.0.0-beta.6",
     "@springio/antora-extensions": "1.14.12",
-    "@springio/asciidoctor-extensions": "1.0.0-alpha.18",
-    "asciidoctor-kroki": "0.18.1"
+    "@springio/asciidoctor-extensions": "1.0.0-alpha.18"
   }
 }


### PR DESCRIPTION
Removes `asciidoctor-kroki` from `package.json` on `docs-build`.

This dependency is not referenced by the Antora playbook/extensions used for docs generation, and docs content from the configured branches/tags does not use Kroki diagram blocks.