### PR TITLE
Exclude release train workflows from GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
Dependabot GitHub Actions update PRs should not modify release train workflow dependencies, since those workflow files are intentionally managed outside the regular update flow.

This change adds `exclude-paths` to the `github-actions` entry in `.github/dependabot.yml` so Dependabot ignores:
- `.github/workflows/release-train-test.yml`
- `.github/workflows/release-train-build.yml`

The rest of the Dependabot configuration is unchanged.