### PR TITLE
Remove branch check when setting up JDK

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -110,7 +110,6 @@ jobs:
         uses: ./.github/workflows/composites/setup-jdk
         with:
           jdk-version: ${{ env.JDK_VERSION }}
-        if: env.BASE_BRANCH == 'main' || env.BASE_BRANCH == '3.0.x' || env.BASE_BRANCH == '3.1.x'
 
       - name: cache local maven repository
         uses: ./.github/workflows/composites/cache
@@ -213,7 +212,6 @@ jobs:
         uses: ./.github/workflows/composites/setup-jdk
         with:
           jdk-version: ${{ env.JDK_VERSION }}
-        if: env.BASE_BRANCH == 'main' || env.BASE_BRANCH == '3.0.x' || env.BASE_BRANCH == '3.1.x'
 
       - name: pre-test-actions
         uses: ./.github/workflows/composites/pre-test-actions
@@ -280,7 +278,6 @@ jobs:
         uses: ./.github/workflows/composites/setup-jdk
         with:
           jdk-version: ${{ env.JDK_VERSION }}
-        if: env.BASE_BRANCH == 'main' || env.BASE_BRANCH == '3.0.x' || env.BASE_BRANCH == '3.1.x'
 
       - name: pre-test-actions
         uses: ./.github/workflows/composites/pre-test-actions


### PR DESCRIPTION
At this point all branches will be using jdk 17 so I dont think this is necessary