### PR TITLE
Keep Running All Test Jobs and Add Retry Functionality

### DIFF
--- a/.github/workflows/composites/build-controllers-project/action.yaml
+++ b/.github/workflows/composites/build-controllers-project/action.yaml
@@ -8,6 +8,11 @@ runs:
       env:
         CURRENT_INDEX: ${{ matrix.current_index }}
       run: |
+        # this builds the controller docker images via the paketo buildpacks, which pull a
+        # JRE and the buildpack images over the network, so it fails for transient reasons
+        # that have nothing to do with the build. retry it, see the script.
+        RETRY="${GITHUB_WORKSPACE}/.github/workflows/composites/scripts/retry-command.sh"
+
         cd spring-cloud-kubernetes-controllers
-        .././mvnw $MAVEN_SETTINGS -DCURRENT_INSTANCE=${CURRENT_INDEX} -T 1C -U clean install
+        "${RETRY}" .././mvnw $MAVEN_SETTINGS -DCURRENT_INSTANCE=${CURRENT_INDEX} -T 1C -U clean install
         cd ..

--- a/.github/workflows/composites/build-integration-tests-project/action.yaml
+++ b/.github/workflows/composites/build-integration-tests-project/action.yaml
@@ -6,12 +6,16 @@ runs:
     - name: build integration tests project without tests
       shell: bash
       run: |
-        
+
+        # both of these reach out to the network, the second one to build the docker images
+        # via the paketo buildpacks, so retry them, see the script.
+        RETRY="${GITHUB_WORKSPACE}/.github/workflows/composites/scripts/retry-command.sh"
+
         cd spring-cloud-kubernetes-test-support
-        .././mvnw $MAVEN_SETTINGS clean install -U
+        "${RETRY}" .././mvnw $MAVEN_SETTINGS clean install -U
         cd ..
-        
+
         cd spring-cloud-kubernetes-integration-tests
         # build the images, but dont run the tests
-        .././mvnw $MAVEN_SETTINGS -T 1C clean install -DskipTests
+        "${RETRY}" .././mvnw $MAVEN_SETTINGS -T 1C clean install -DskipTests
         cd ..

--- a/.github/workflows/composites/cache/action.yaml
+++ b/.github/workflows/composites/cache/action.yaml
@@ -13,8 +13,11 @@ runs:
       with:
         attempt_limit: 3
         action: buildjet/cache@v3
+        # '~/.m2/wrapper' holds the maven distribution that ./mvnw downloads for itself.
         with: |
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-cache-jdk${{ inputs.jdk-version }}-${{ env.BRANCH_NAME }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-cache-jdk${{ inputs.jdk-version }}-${{ env.BRANCH_NAME }}-${{ hashFiles('**/pom.xml') }}
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-cache-v2-jdk${{ inputs.jdk-version }}-${{ env.BRANCH_NAME }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-cache-v2-jdk${{ inputs.jdk-version }}-${{ env.BRANCH_NAME }}-${{ hashFiles('**/pom.xml') }}
         

--- a/.github/workflows/composites/pre-test-actions/action.yaml
+++ b/.github/workflows/composites/pre-test-actions/action.yaml
@@ -37,7 +37,14 @@ runs:
     - name: build project
       shell: bash
       run: |
-        ./mvnw $MAVEN_SETTINGS clean install -Dspring-boot.build-image.skip=true -DskipITs -DskipTests -T1C -U -B -q
+        # this is the first ./mvnw of the job, so it is also the one that makes the maven
+        # wrapper download maven itself. Only ~/.m2/repository is cached, not
+        # ~/.m2/wrapper, so every shard downloads apache-maven-<version>-bin.zip from
+        # maven central at the same moment and central answers some of them with
+        # 'HTTP response code: 429'. Retry it, see the script.
+        RETRY="${GITHUB_WORKSPACE}/.github/workflows/composites/scripts/retry-command.sh"
+
+        "${RETRY}" ./mvnw $MAVEN_SETTINGS clean install -Dspring-boot.build-image.skip=true -DskipITs -DskipTests -T1C -U -B -q
 
     # we could cache these images also, but the vast majority of time, we will
     # be running against a SNAPSHOT version.

--- a/.github/workflows/composites/run-and-save-test-times-when-cache-missing/action.yaml
+++ b/.github/workflows/composites/run-and-save-test-times-when-cache-missing/action.yaml
@@ -46,19 +46,10 @@ runs:
         TEST_ARG=$(echo ${sliced_array[@]} | sed 's/ /,/g')
         echo "$TEST_ARG"
         
-        ./mvnw $MAVEN_SETTINGS \
-            -DtestsToRun=${TEST_ARG[@]} \
-            -DCURRENT_INSTANCE=${CURRENT_INDEX} \
-            -e clean install \
-            -P sonar -nsu --batch-mode \
-            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-            -Dhttp.keepAlive=false \
-            -Dmaven.wagon.http.pool=false \
-            -Dmaven.wagon.http.retryHandler.class=standard \
-            -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
-            -Dmaven.wagon.http.retryHandler.count=3 \
-            -Dmaven.resolver.transport=wagon \
-            -Dspring-boot.build-image.skip=true          
+        # runs the tests, then re-runs only the classes that failed, see the script
+        ./.github/workflows/composites/scripts/run-tests-with-retry.sh \
+            "${TEST_ARG}" \
+            -DCURRENT_INSTANCE=${CURRENT_INDEX}
         
         touch /tmp/test_times_${{ env.CURRENT_INDEX }}.txt
         

--- a/.github/workflows/composites/run-and-save-test-times-when-cache-present/action.yaml
+++ b/.github/workflows/composites/run-and-save-test-times-when-cache-present/action.yaml
@@ -154,20 +154,11 @@ runs:
         
         echo "will run tests : $tests_to_run_in_current_index"
         
-        ./mvnw $MAVEN_SETTINGS \
-              -DtestsToRun=${tests_to_run_in_current_index} \
+        # runs the tests, then re-runs only the classes that failed, see the script
+        ./.github/workflows/composites/scripts/run-tests-with-retry.sh \
+              "${tests_to_run_in_current_index}" \
               -Dsurefire-reports-directory=surefire-reports/${CURRENT_INDEX} \
-              -Dfailsafe-reports-directory=failsafe-reports/${CURRENT_INDEX} \
-              -e clean install \
-              -P sonar -nsu --batch-mode \
-              -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-              -Dhttp.keepAlive=false \
-              -Dmaven.wagon.http.pool=false \
-              -Dmaven.wagon.http.retryHandler.class=standard \
-              -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
-              -Dmaven.wagon.http.retryHandler.count=3 \
-              -Dmaven.resolver.transport=wagon \
-              -Dspring-boot.build-image.skip=true
+              -Dfailsafe-reports-directory=failsafe-reports/${CURRENT_INDEX}
         
         touch /tmp/test_times_${{ env.CURRENT_INDEX }}.txt
         

--- a/.github/workflows/composites/scripts/retry-command.sh
+++ b/.github/workflows/composites/scripts/retry-command.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Runs a command and re-runs it from scratch if it fails.
+#
+# This exists for the steps that build the docker images, which happen before any test
+# runs and are therefore not covered by run-tests-with-retry.sh. Those steps fail for
+# reasons that have nothing to do with this project: the paketo buildpacks download a JRE
+# and the buildpack images from the network on every build, so a reset connection or a
+# slow mirror fails the whole shard about twenty minutes before it would have finished.
+# A real example, which is what prompted this script:
+#
+#   BellSoft Liberica JRE 17.0.20: Contributing to layer
+#     Downloading from https://github.com/bell-sw/Liberica/releases/download/...
+#   fetching dependency BellSoft Liberica JRE failed
+#   Get "https://release-assets.githubusercontent.com/...": read tcp ...: read: connection
+#   reset by peer
+#   ERROR: failed to build: exit status 1
+#
+# In that same build a module running in parallel downloaded the very same JRE half a
+# second later without trouble, so simply doing it again is the entire fix.
+#
+# Unlike run-tests-with-retry.sh this retries the whole command rather than narrowing it.
+# There are no test reports to narrow against at this point in the job, and re-running
+# 'clean install' is cheap next to losing the shard.
+#
+# Usage: retry-command.sh <command> [args...]
+
+set -eo pipefail
+
+# Number of extra attempts after the first one. 0 disables retrying.
+MAX_RETRIES="${COMMAND_RETRY_COUNT:-2}"
+# Seconds to wait before the first retry. Multiplied by the attempt number, so with the
+# default the waits are 15s and then 30s, giving a blipping mirror a moment to recover.
+RETRY_DELAY="${COMMAND_RETRY_DELAY:-15}"
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: retry-command.sh <command> [args...]" >&2
+  exit 2
+fi
+
+# Leaves a note in the job summary so a step that only went green on a retry is visible
+# in the run overview instead of being buried in tens of thousands of log lines.
+note_retry() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "- shard \`${CURRENT_INDEX:-?}\`: \`$1\` succeeded on attempt $2 of $3" \
+      >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+main() {
+  local attempt=0
+  local rc=0
+  local delay
+  local total=$(( MAX_RETRIES + 1 ))
+
+  while true; do
+    set +e
+    "$@"
+    rc=$?
+    set -e
+
+    if [[ $rc -eq 0 ]]; then
+      if [[ $attempt -gt 0 ]]; then
+        echo "=========================================================================="
+        echo "command succeeded on attempt $(( attempt + 1 )) of ${total}"
+        echo "=========================================================================="
+        note_retry "$1" "$(( attempt + 1 ))" "${total}"
+      fi
+      return 0
+    fi
+
+    # Out of budget. Keep the command's own exit code so the step fails exactly as it
+    # would have without this wrapper.
+    if [[ $attempt -ge $MAX_RETRIES ]]; then
+      echo "=========================================================================="
+      echo "command failed with exit code ${rc} after ${total} attempt(s), giving up"
+      echo "=========================================================================="
+      return $rc
+    fi
+
+    attempt=$(( attempt + 1 ))
+    delay=$(( RETRY_DELAY * attempt ))
+
+    echo "=========================================================================="
+    echo "command failed with exit code ${rc}"
+    echo "retrying in ${delay}s (attempt $(( attempt + 1 )) of ${total}): $*"
+    echo "=========================================================================="
+    sleep "${delay}"
+  done
+}
+
+main "$@"

--- a/.github/workflows/composites/scripts/run-tests-with-retry.sh
+++ b/.github/workflows/composites/scripts/run-tests-with-retry.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+# Runs one shard of the test suite, then retries only the test classes that failed.
+#
+# The test matrices in maven.yaml are 'fail-fast: false', so every shard now runs to
+# completion. That makes a single flaky shard fail the whole build on its own, and the
+# integration tests here start k3s/testcontainers in @BeforeAll, which is exactly the
+# kind of failure that does not reproduce on a second run. Re-running the entire shard
+# would cost tens of minutes, so instead we re-run only the classes whose surefire or
+# failsafe report records a failure, in a fresh Maven invocation so that the containers
+# are started from scratch.
+#
+# The retry set is deliberately not just "the classes that failed". Maven is run with
+# '--fail-at-end' so that one failing module no longer stops the reactor before the later
+# modules of the shard have run, but modules that depend on a failed one are still
+# skipped. Any class of this shard that produced no report therefore never ran, and is
+# retried alongside the ones that failed. Without that, a retry that fixes the flaky class
+# would report a green shard whose remaining tests were never executed.
+#
+# Usage: run-tests-with-retry.sh <comma-separated-test-classes> [extra mvn args...]
+
+set -eo pipefail
+
+TESTS_TO_RUN="$1"
+shift
+
+# Number of extra attempts after the initial run. Set TEST_RETRY_COUNT=0 to disable
+# retries entirely and get the previous behaviour back.
+MAX_RETRIES="${TEST_RETRY_COUNT:-1}"
+
+# $MAVEN_SETTINGS is deliberately unquoted: it holds '--settings <path>', which has to
+# word-split into two arguments. This mirrors how the other composites invoke mvnw.
+mvn_run() {
+  local tests="$1"
+  shift
+
+  ./mvnw $MAVEN_SETTINGS \
+      -DtestsToRun="${tests}" \
+      "$@" \
+      -P sonar -nsu --batch-mode --fail-at-end \
+      -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+      -Dhttp.keepAlive=false \
+      -Dmaven.wagon.http.pool=false \
+      -Dmaven.wagon.http.retryHandler.class=standard \
+      -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
+      -Dmaven.wagon.http.retryHandler.count=3 \
+      -Dmaven.resolver.transport=wagon \
+      -Dspring-boot.build-image.skip=true
+}
+
+# Fully qualified names of the test classes whose report records a failure or an error.
+# Surefire and failsafe both write one plain text report per class, named <FQCN>.txt,
+# holding a summary line that looks like:
+#   Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.2 s <<< FAILURE!
+# Note that the reports directory is not fixed: the cache-present shards redirect it to
+# surefire-reports/<index>, hence matching on the path rather than on a literal dir.
+failed_test_classes() {
+  local report name
+
+  while IFS= read -r -d '' report; do
+    if grep -q -E 'Tests run:.*(Failures: [1-9]|Errors: [1-9])' "${report}"; then
+      name="${report##*/}"
+      echo "${name%.txt}"
+    fi
+  done < <(find . -type f \
+                \( -path '*surefire-reports*' -o -path '*failsafe-reports*' \) \
+                -name '*.txt' ! -name '*-output.txt' -print0) \
+    | sort -u \
+    | paste -sd, -
+}
+
+# Fully qualified names of the test classes that were asked for but produced no report
+# at all, meaning they never ran.
+#
+# This is not a theoretical case. The reactor is 41 modules deep and a shard's classes are
+# spread across many of them, so when one module fails, '--fail-at-end' still skips every
+# module that depends on the failed one. Those classes have to be carried into the retry,
+# otherwise a retry that fixes the flaky class lets the shard go green while tests that
+# were never executed are silently dropped.
+
+# Drops the entries of a comma separated test list that are not real class names: 'none'
+# is the sentinel the cache-present composite uses for an index that has no tests, and
+# empty entries show up when a slice runs past the end of the test list.
+clean_list() {
+  local test
+  local -a input=() kept=()
+
+  IFS=',' read -r -a input <<< "$1"
+  for test in "${input[@]}"; do
+    if [[ -n "${test}" && "${test}" != "none" ]]; then
+      kept+=("${test}")
+    fi
+  done
+
+  ( IFS=','; echo "${kept[*]}" )
+}
+
+never_ran_test_classes() {
+  local requested
+  local existing test
+  local -a requested_array=() missing=()
+
+  requested=$(clean_list "$1")
+
+  # one pass over the reports, turning 'target/failsafe-reports/3/org.foo.BarIT.txt' into
+  # 'org.foo.BarIT'. Report basenames are class names, so they never contain a space.
+  existing=$(find . -type f \
+                  \( -path '*surefire-reports*' -o -path '*failsafe-reports*' \) \
+                  -name '*.txt' ! -name '*-output.txt' \
+               | sed -e 's|.*/||' -e 's|\.txt$||' \
+               | sort -u)
+
+  IFS=',' read -r -a requested_array <<< "${requested}"
+  for test in "${requested_array[@]}"; do
+    if ! grep -Fxq "${test}" <<< "${existing}"; then
+      missing+=("${test}")
+    fi
+  done
+
+  ( IFS=','; echo "${missing[*]}" )
+}
+
+# Joins the non-empty arguments with commas, so an empty failed set or an empty never-ran
+# set does not produce a leading or doubled comma in '-DtestsToRun'.
+join_non_empty() {
+  local part joined=''
+
+  for part in "$@"; do
+    if [[ -n "${part}" ]]; then
+      if [[ -z "${joined}" ]]; then joined="${part}"; else joined="${joined},${part}"; fi
+    fi
+  done
+
+  echo "${joined}"
+}
+
+# Leaves a note in the job summary so a shard that only went green on a retry is
+# visible in the run overview instead of being buried in the log.
+note_retry() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "- shard \`${CURRENT_INDEX:-?}\`: retried failed test classes -> \`$1\`" \
+      >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+main() {
+  local attempt=0
+  local rc=0
+  local failed never_ran retry_set
+  # the set of classes this attempt is accountable for. It narrows on every retry, since
+  # the classes that already passed do not need to be run or accounted for again.
+  local outstanding="${TESTS_TO_RUN}"
+
+  set +e
+  mvn_run "${TESTS_TO_RUN}" "$@" -e clean install
+  rc=$?
+  set -e
+
+  while [[ $rc -ne 0 && $attempt -lt $MAX_RETRIES ]]; do
+    attempt=$(( attempt + 1 ))
+
+    failed=$(failed_test_classes)
+    never_ran=$(never_ran_test_classes "${outstanding}")
+    retry_set=$(join_non_empty "${failed}" "${never_ran}")
+
+    # Nothing to retry: every test this shard was asked for ran and passed, yet Maven
+    # still failed. The failure is therefore somewhere other than the tests, typically a
+    # later phase of a module whose tests were already green (packaging, the image build,
+    # installing into the local repository).
+    #
+    # This must return rather than fall through. Retrying with an empty test set would
+    # expand '<include>${testsToRun}</include>' to nothing, match zero classes and exit 0,
+    # silently reporting a green shard for a build that failed.
+    if [[ -z "${retry_set}" ]]; then
+      echo "maven failed but every test of this shard produced a passing report, so the"
+      echo "failure is outside the tests (packaging, image build, install, ...)."
+      echo "not retrying."
+      return $rc
+    fi
+
+    # Nothing failed and nothing ran: Maven died before it got as far as testing, which
+    # means this is not a test failure but a compilation error, a dependency that would
+    # not resolve, the runner running out of disk. A retry would fail in exactly the same
+    # way, so keep the original exit code instead of paying for another full build.
+    if [[ -z "${failed}" ]] && [[ "${never_ran}" == "$(clean_list "${outstanding}")" ]]; then
+      echo "maven failed but no test of this shard produced a report, so this is not a"
+      echo "test failure (compilation, dependency resolution, the runner itself, ...)."
+      echo "not retrying."
+      return $rc
+    fi
+
+    echo "=============================================================================="
+    echo "attempt ${attempt} of ${MAX_RETRIES}: re-running the following test classes"
+    if [[ -n "${failed}" ]]; then
+      echo "-- failed:"
+      echo "${failed}" | tr ',' '\n'
+    fi
+    if [[ -n "${never_ran}" ]]; then
+      # Maven stops descending into the modules that depend on a failed one, so these were
+      # requested by this shard but never got the chance to run.
+      echo "-- never ran (their module was skipped after an earlier module failed):"
+      echo "${never_ran}" | tr ',' '\n'
+    fi
+    echo "=============================================================================="
+    note_retry "${retry_set}"
+
+    outstanding="${retry_set}"
+
+    # No 'clean' on the retry, on purpose. It would delete the reports of the classes
+    # that already passed, and the steps after this one read every report to work out
+    # how long each test took. Re-running writes fresh reports for the retried classes
+    # only, which is exactly the bookkeeping we want.
+    set +e
+    mvn_run "${retry_set}" "$@" -e install
+    rc=$?
+    set -e
+  done
+
+  return $rc
+}
+
+main "$@"

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -191,7 +191,9 @@ jobs:
     timeout-minutes: 120
 
     strategy:
-      fail-fast: true
+      # let every shard finish so a single failing shard does not hide failures
+      # (or successes) in the others
+      fail-fast: false
       matrix:
         current_index: [ "${{ fromJSON(needs.build.outputs.matrix_array) }}" ]
         number_of_jobs: [ "${{ fromJSON(needs.build.outputs.number_of_matrix_instances) }}" ]
@@ -243,6 +245,9 @@ jobs:
           CURRENT_INDEX: ${{ matrix.current_index }}
           NUMBER_OF_JOBS: ${{ matrix.number_of_jobs }}
           AVERAGE_TIME_PER_INSTANCE: ${{ matrix.average_time_per_instance }}
+          # how many extra times a shard re-runs the test classes that failed.
+          # 0 disables retries, 2 means up to three maven runs, and so on.
+          TEST_RETRY_COUNT: 1
 
   test_when_cache_missing:
     name: Test without cache (runner ${{ matrix.current_index }})
@@ -258,7 +263,9 @@ jobs:
     if: needs.build.outputs.test_times_cache_present == 'false'
 
     strategy:
-      fail-fast: true
+      # let every shard finish so a single failing shard does not hide failures
+      # (or successes) in the others
+      fail-fast: false
       matrix:
         current_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
         number_of_jobs: [32]
@@ -313,6 +320,9 @@ jobs:
           branch: ${{ env.BRANCH_SAFE }}
         env:
           CURRENT_INDEX: ${{ matrix.current_index }}
+          # how many extra times a shard re-runs the test classes that failed.
+          # 0 disables retries, 2 means up to three maven runs, and so on.
+          TEST_RETRY_COUNT: 1
 
   save_test_times_when_cache_missing:
     name: Save test times


### PR DESCRIPTION
Remove fail fast so other test runners continue running on failure. 
Add retry functionality to retry failed tests