### PR TITLE
Allow configuring the directory used to stage local image tar files

### DIFF
--- a/spring-cloud-kubernetes-integration-tests/README
+++ b/spring-cloud-kubernetes-integration-tests/README
@@ -33,3 +33,27 @@ Notice this line:
     <imageName>docker.io/springcloud/${project.artifactId}:${project.version}</imageName>
 
 You must follow the same convention.
+
+
+Running the integration tests locally with a VM based Docker runtime
+--------------------------------------------------------------------
+
+Integration tests build a docker image locally, save it as a tar file and bind mount the
+directory holding that tar into the k3s container, so that it can be imported with
+'ctr i import'.
+
+By default that directory is 'java.io.tmpdir'. Docker runtimes that run inside a virtual
+machine (colima, Rancher Desktop, ...) only share a subset of the host filesystem with
+that virtual machine, and on macOS 'java.io.tmpdir' ('/var/folders/...') is usually not
+shared. The bind mount then resolves to an empty directory inside the virtual machine and
+the tests fail with:
+
+    ctr: open /var/folders/.../<image-name>.tar: no such file or directory
+
+To fix this, point the tests to a directory that the virtual machine does share, for
+example one under the user home:
+
+    -Dspring.cloud.kubernetes.integration.tests.image-tars-dir=${HOME}/.spring-cloud-kubernetes-image-tars
+
+The same value can be provided via the SPRING_CLOUD_KUBERNETES_IMAGE_TARS_DIR environment
+variable.

--- a/spring-cloud-kubernetes-test-support/src/main/java/org/springframework/cloud/kubernetes/integration/tests/commons/Constants.java
+++ b/spring-cloud-kubernetes-test-support/src/main/java/org/springframework/cloud/kubernetes/integration/tests/commons/Constants.java
@@ -23,9 +23,15 @@ import java.io.File;
  */
 final class Constants {
 
-	private Constants() {
+	/**
+	 * System property that overrides the directory used to stage local image tar files.
+	 */
+	static final String LOCAL_IMAGE_TARS_DIR_PROPERTY = "spring.cloud.kubernetes.integration.tests.image-tars-dir";
 
-	}
+	/**
+	 * Environment variable equivalent of {@link #LOCAL_IMAGE_TARS_DIR_PROPERTY}.
+	 */
+	static final String LOCAL_IMAGE_TARS_DIR_ENV = "SPRING_CLOUD_KUBERNETES_IMAGE_TARS_DIR";
 
 	/**
 	 * Directory populated by the CI pipeline with prebuilt image tar files. It contains
@@ -41,12 +47,42 @@ final class Constants {
 	/**
 	 * Directory used during local runs to stage image tar files created from the local
 	 * Docker cache before importing them into K3s with 'ctr i import'.
+	 * <p>
+	 * This directory is bind mounted into the K3s container, so it must be visible to the
+	 * Docker daemon. Docker runtimes that run inside a virtual machine (colima, Rancher
+	 * Desktop, minikube, ...) only share a subset of the host filesystem with that
+	 * virtual machine, and 'java.io.tmpdir' (on macOS '/var/folders/...') is typically
+	 * not part of it. In that case the bind mount silently resolves to an empty directory
+	 * inside the virtual machine and 'ctr i import' fails with 'no such file or
+	 * directory'. Such setups can point this directory to a shared location (for example
+	 * one under the user home) with {@link #LOCAL_IMAGE_TARS_DIR_PROPERTY} or
+	 * {@link #LOCAL_IMAGE_TARS_DIR_ENV}.
 	 */
-	static final String LOCAL_IMAGE_TARS_DIR = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+	static final String LOCAL_IMAGE_TARS_DIR = localImageTarsDir();
 
 	/**
 	 * where is the version situated.
 	 */
 	static final String KUBERNETES_VERSION_FILE = "META-INF/springcloudkubernetes-version.txt";
+
+	private Constants() {
+
+	}
+
+	private static String localImageTarsDir() {
+		String configured = System.getProperty(LOCAL_IMAGE_TARS_DIR_PROPERTY);
+		if (configured == null || configured.isBlank()) {
+			configured = System.getenv(LOCAL_IMAGE_TARS_DIR_ENV);
+		}
+
+		File dir = new File(
+				configured == null || configured.isBlank() ? System.getProperty("java.io.tmpdir") : configured);
+
+		if (!dir.isDirectory() && !dir.mkdirs()) {
+			throw new IllegalStateException("could not create image tars directory : " + dir.getAbsolutePath());
+		}
+
+		return dir.getAbsolutePath();
+	}
 
 }


### PR DESCRIPTION
Fixes gh-1602

### Problem

Integration tests build a docker image locally, save it as a tar with `docker image save`, and bind mount the directory holding that tar into the k3s container so it can be imported with `ctr i import`. That directory is hardcoded to `java.io.tmpdir`:

```java
static final String LOCAL_IMAGE_TARS_DIR = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
```

and bind mounted in `FixedPortsK3sContainer`:

```java
hostConfig.withBinds(Bind.parse(LOCAL_IMAGE_TARS_DIR + ":" + LOCAL_IMAGE_TARS_DIR), ...);
```

Bind mounts are resolved by the docker daemon. With a VM based runtime (colima, Rancher Desktop, ...) the daemon runs inside a virtual machine that only shares part of the host filesystem, and on macOS `java.io.tmpdir` (`/var/folders/...`) is normally not shared. Docker then creates an *empty* directory for the bind instead of failing, the tar written on the host is invisible inside the container, and the import fails with the error reported in the issue:

```
ctr: open /var/folders/.../spring-cloud-kubernetes-fabric8-client-istio.tar: no such file or directory
```

This is not specific to `Fabric8IstioIT` — it affects every integration test that loads a locally built image.

### Reproducing it

On colima the VM shares only the user home:

```
$ colima ssh -- mount | grep virtiofs
mount0 on /Users/<user> type virtiofs (rw,relatime)

$ colima ssh -- ls /var/folders/bv/.../T/
ls: cannot access '/var/folders/bv/.../T/': No such file or directory
```

Writing a file to the host temp dir and bind mounting that dir the same way the tests do:

```
$ echo marker-from-host > $TMPDIR/sck-repro.tar
$ docker run --rm -v "$TMPDIR:$TMPDIR" alpine:3 sh -c "ls -la $TMPDIR; cat $TMPDIR/sck-repro.tar"
total 8
drwxr-xr-x    2 root     root          4096 .
drwxr-xr-x    3 root     root          4096 ..
cat: can't open '/var/folders/bv/.../T/sck-repro.tar': No such file or directory
```

The directory is mounted, but empty. Doing the same with a directory under the user home works:

```
$ docker run --rm -v "$HOME/.sck-image-tars:$HOME/.sck-image-tars" alpine:3 cat $HOME/.sck-image-tars/sck-repro.tar
marker-from-host
```

### Change

Make the staging directory configurable, via the `spring.cloud.kubernetes.integration.tests.image-tars-dir` system property or the `SPRING_CLOUD_KUBERNETES_IMAGE_TARS_DIR` environment variable, and create it if it does not exist. The default remains `java.io.tmpdir`, so CI and Docker Desktop behaviour is unchanged.

Users on a VM based runtime can then run:

```
-Dspring.cloud.kubernetes.integration.tests.image-tars-dir=${HOME}/.spring-cloud-kubernetes-image-tars
```

The integration tests README documents this, including the exact error message so it is searchable.

### Verification

To be explicit about what I did and did not run:

- the bind mount behaviour above was reproduced directly on colima, in both the failing and the working configuration
- `spring-cloud-kubernetes-test-support` compiles and passes `spring-javaformat:validate`
- I have **not** yet run `Fabric8IstioIT` end to end with the new property

Happy to do the full istio run and report back, and equally happy to change the property name or drop the environment variable if you would rather keep the surface smaller.
